### PR TITLE
feat(server): add username for auth

### DIFF
--- a/apps/client/src/features/auth/store/userAuthStore.ts
+++ b/apps/client/src/features/auth/store/userAuthStore.ts
@@ -221,6 +221,7 @@ export function createUserAuthStore(
           const response = await activeGateway.signInAnonymously({
             name: nextDisplayName,
             displayName: nextDisplayName,
+            username: nextDisplayName,
             metadata,
           });
 

--- a/apps/client/tests/features/auth/store/userAuthStore.test.ts
+++ b/apps/client/tests/features/auth/store/userAuthStore.test.ts
@@ -104,6 +104,7 @@ describe("user auth store", () => {
     expect(gateway.signInAnonymously).toHaveBeenCalledWith({
       name: "Scout",
       displayName: "Scout",
+      username: "Scout",
       metadata: {},
     });
     expect(store.getState().status).toBe("authenticated");

--- a/apps/server/src/infra/db/interfaces.ts
+++ b/apps/server/src/infra/db/interfaces.ts
@@ -5,6 +5,7 @@ export interface IUser {
   id: string; // Mongoose _id as string
   email?: string;
   password?: string; // Hashed password
+  username?: string; // Display name
   anonymous?: boolean;
   verified?: boolean;
   elo?: number; // Player's ranking score

--- a/apps/server/src/infra/db/models/user-model.ts
+++ b/apps/server/src/infra/db/models/user-model.ts
@@ -4,6 +4,7 @@ import mongoose, { Schema } from "mongoose";
 export interface IUserDocument extends Document {
   email?: string;
   password?: string;
+  username?: string;
   anonymous: boolean;
   verified: boolean;
   elo: number;
@@ -13,6 +14,7 @@ const UserSchema = new Schema<IUserDocument>(
   {
     email: { type: String, unique: true, sparse: true, trim: true },
     password: { type: String }, // Stores hashed password from @colyseus/auth
+    username: { type: String, trim: true },
     anonymous: { type: Boolean, default: false },
     verified: { type: Boolean, default: false },
     elo: { type: Number, default: 1000 },

--- a/apps/server/src/infra/db/repositories/MongoUserRepository.ts
+++ b/apps/server/src/infra/db/repositories/MongoUserRepository.ts
@@ -18,6 +18,7 @@ export class MongoUserRepository implements IUserRepository {
       id: doc._id.toString(),
       email: doc.email,
       password: doc.password,
+      username: doc.username,
       anonymous: doc.anonymous,
       verified: doc.verified,
       elo: doc.elo,


### PR DESCRIPTION
Closes #22 .

This pull request adds support for a `username` field to user data throughout the authentication and user management system. The changes ensure that usernames are stored, retrieved, and handled consistently for both anonymous and registered users.

**User model and database schema updates:**

* Added a `username` field to the `IUser` interface, the `IUserDocument` interface, and the Mongoose `UserSchema` to store display names or usernames for users. [[1]](diffhunk://#diff-96df7983c6a5a2ceeb7f8f087414d2413318da5b01713e7d9ec1352773b03951R8) [[2]](diffhunk://#diff-dd32acc2ca9c302f5166833f25c56681fb073201bf84a04ad1233c1f932d3913R7) [[3]](diffhunk://#diff-dd32acc2ca9c302f5166833f25c56681fb073201bf84a04ad1233c1f932d3913R17)

**Repository and data handling:**

* Updated the `MongoUserRepository` to include the `username` field when mapping user documents to data objects.

**Authentication flow:**

* Modified the anonymous sign-in process in the client-side `userAuthStore` to send the `username` field (using the display name) when creating a new anonymous user.