### PR TITLE
chore(lefthook): run a complete lint in pre-push and move type-check to pre-push

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -5,14 +5,18 @@ pre-commit:
       glob: "*.{js,ts,jsx,tsx,json}"
       run: pnpm exec biome check --write --no-errors-on-unmatched {staged_files} && git add {staged_files}
 
-    type-check:
-      run: pnpm type-check
-
     test-related:
       glob: "*.{ts,tsx}"
       run: pnpm vitest related --run {staged_files}
 
 pre-push:
+  parallel: true
   commands:
+    lint-all:
+      run: pnpm lint
+
+    type-check:
+      run: pnpm type-check
+
     test-all:
       run: pnpm test


### PR DESCRIPTION
Closes #24 