### PR TITLE
feat: implement turf war mode

### DIFF
--- a/packages/engine/src/domain/game/turf-war-game.ts
+++ b/packages/engine/src/domain/game/turf-war-game.ts
@@ -1,0 +1,159 @@
+import { ActionType } from "#/domain/action/action-type";
+import type { Action } from "#/domain/action/interfaces";
+import type { ICell } from "#/domain/cell/interfaces";
+import { Terrain } from "#/domain/cell/terrain";
+import { RespawningCombatResolver } from "#/domain/combat/respawning-combat-resolver";
+import { EffectType } from "#/domain/effect/effect-type";
+import { TroopModifierEffect } from "#/domain/effect/periodic/troop-modifier";
+import { BaseGame } from "#/domain/game/base-game";
+import { GameMode } from "#/domain/game/game-mode";
+import type { IGameResult } from "#/domain/game/game-result";
+import { GameStatus } from "#/domain/game/game-status";
+import type {
+  ITurfWarGame,
+  ITurfWarScoreboard,
+} from "#/domain/game/interfaces";
+import { PlayerStatus } from "#/domain/player/player-status";
+
+export class TurfWarGame extends BaseGame implements ITurfWarGame {
+  public readonly mode = GameMode.TURF_WAR;
+  private readonly combatResolver = new RespawningCombatResolver();
+  private readonly MAX_TICKS = 360; // 3 minutes at 2 ticks/sec
+
+  public startGame(): void {
+    super.startGame();
+    this.assignStartPositions();
+
+    // Double troop generation speed
+    this.effectRegistry.register(
+      this.tick,
+      new TroopModifierEffect(this.tick, {
+        id: "turfwar-general-troop-gen",
+        type: EffectType.TROOP_GENERATION,
+        target: this.grid,
+        terrain: Terrain.GENERAL,
+        delta: 2,
+        interval: 1,
+      }),
+    );
+
+    this.effectRegistry.register(
+      this.tick,
+      new TroopModifierEffect(this.tick, {
+        id: "turfwar-city-troop-gen",
+        type: EffectType.TROOP_GENERATION,
+        target: this.grid,
+        terrain: Terrain.CITY,
+        delta: 2,
+        interval: 1,
+      }),
+    );
+
+    this.effectRegistry.register(
+      this.tick,
+      new TroopModifierEffect(this.tick, {
+        id: "turfwar-plain-troop-gen",
+        type: EffectType.TROOP_GENERATION,
+        target: this.grid,
+        terrain: Terrain.PLAIN,
+        delta: 2,
+        interval: 25,
+      }),
+    );
+  }
+
+  protected executeAction(action: Action): boolean {
+    if (action.type !== ActionType.MOVE) {
+      return false;
+    }
+    const success = this.combatResolver.execute(
+      action,
+      this.grid,
+      this.players,
+    );
+
+    if (success) {
+      this.checkGameEnd();
+    }
+
+    return success;
+  }
+
+  public nextTick(): void {
+    if (this.status !== GameStatus.PLAYING) {
+      return;
+    }
+
+    super.nextTick();
+
+    this.checkGameEnd();
+  }
+
+  protected evaluateGameEnd(): IGameResult | null {
+    const aliveTeams = this.getAliveTeams();
+
+    // Win condition 1: Only one team left
+    if (aliveTeams.size <= 1) {
+      return {
+        mode: this.mode,
+        winnerTeamId: aliveTeams.values().next().value ?? null,
+      };
+    }
+
+    // Win condition 2: Time limit reached (3 minutes)
+    if (this.tick >= this.MAX_TICKS) {
+      // Count land per team
+      const teamLand = new Map<string, number>();
+      this.grid.forEach((cell) => {
+        if (cell.owner && cell.owner.status === PlayerStatus.ACTIVE) {
+          const player = this.players.get(cell.owner.playerId);
+          if (player) {
+            const teamId = player.team.teamId;
+            teamLand.set(teamId, (teamLand.get(teamId) ?? 0) + 1);
+          }
+        }
+      });
+
+      let winnerTeamId: string | null = null;
+      let maxLand = -1;
+
+      for (const [teamId, land] of teamLand.entries()) {
+        if (land > maxLand) {
+          maxLand = land;
+          winnerTeamId = teamId;
+        } else if (land === maxLand) {
+          winnerTeamId = null; // Tie
+        }
+      }
+
+      return {
+        mode: this.mode,
+        winnerTeamId,
+      };
+    }
+
+    return null;
+  }
+
+  public getScoreboard(): ITurfWarScoreboard {
+    const baseScores = this.calculateBaseScores();
+    const players = Array.from(baseScores.entries()).map(
+      ([playerId, score]) => ({
+        playerId,
+        troops: score.troops,
+        land: score.land,
+      }),
+    );
+
+    return {
+      mode: this.mode,
+      players,
+    };
+  }
+
+  protected onCellNeutralized(cell: ICell): void {
+    if (cell.terrain === Terrain.GENERAL) {
+      cell.terrain = Terrain.CITY;
+    }
+  }
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -20,6 +20,7 @@ export * from "#/domain/game/game-mode";
 export * from "#/domain/game/game-result";
 export * from "#/domain/game/game-status";
 export * from "#/domain/game/interfaces";
+export * from "#/domain/game/turf-war-game";
 export * from "#/domain/grid/grid";
 export * from "#/domain/grid/grid-generator";
 export * from "#/domain/grid/interfaces";

--- a/packages/engine/tests/domain/game/turf-war-game.test.ts
+++ b/packages/engine/tests/domain/game/turf-war-game.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import { ActionType } from "#/domain/action/action-type";
+import type { MoveAction } from "#/domain/action/interfaces";
+import { Cell } from "#/domain/cell/cell";
+import { Terrain } from "#/domain/cell/terrain";
+import { GameMode } from "#/domain/game/game-mode";
+import { GameStatus } from "#/domain/game/game-status";
+import { TurfWarGame } from "#/domain/game/turf-war-game";
+import { Grid } from "#/domain/grid/grid";
+import { Player } from "#/domain/player/player";
+import { PlayerStatus } from "#/domain/player/player-status";
+import { StandardTeam } from "#/domain/team/team";
+
+function createGridForTurfWar(): Grid {
+  return new Grid(3, 1, [
+    [
+      new Cell({ coordinate: { x: 0, y: 0 }, terrain: Terrain.GENERAL }),
+      new Cell({ coordinate: { x: 1, y: 0 }, terrain: Terrain.GENERAL }),
+      new Cell({ coordinate: { x: 2, y: 0 }, terrain: Terrain.PLAIN }),
+    ],
+  ]);
+}
+
+function createMoveAction(playerId = "p1"): MoveAction {
+  return {
+    playerId,
+    type: ActionType.MOVE,
+    from: { x: 0, y: 0 },
+    to: { x: 1, y: 0 },
+  };
+}
+
+describe("TurfWarGame", () => {
+  it("finishes game when one alive team remains", () => {
+    const grid = createGridForTurfWar();
+    const game = new TurfWarGame(grid);
+    const t1 = new StandardTeam("t1");
+    const p1 = new Player(t1, "p1", PlayerStatus.ACTIVE);
+    game.players.set(p1.playerId, p1);
+
+    game.startGame();
+    // Simulate nextTick to trigger evaluation or we can just call nextTick
+    game.nextTick();
+
+    expect(game.status).toBe(GameStatus.FINISHED);
+    const result = game.checkGameEnd();
+    expect(result).toEqual({ mode: GameMode.TURF_WAR, winnerTeamId: "t1" });
+  });
+
+  it("finishes game when max ticks reached and returns team with most land", () => {
+    const grid = createGridForTurfWar();
+    const game = new TurfWarGame(grid);
+    const t1 = new StandardTeam("t1");
+    const t2 = new StandardTeam("t2");
+    const p1 = new Player(t1, "p1", PlayerStatus.ACTIVE);
+    const p2 = new Player(t2, "p2", PlayerStatus.ACTIVE);
+    game.players.set(p1.playerId, p1);
+    game.players.set(p2.playerId, p2);
+
+    const c0 = grid.get({ x: 0, y: 0 })!;
+    const c1 = grid.get({ x: 1, y: 0 })!;
+    const c2 = grid.get({ x: 2, y: 0 })!;
+
+    c0.owner = p1;
+    c1.owner = p2;
+    c2.owner = p1; // p1 has 2 tiles, p2 has 1
+
+    game.startGame();
+
+    // Fast forward to MAX_TICKS
+    // @ts-expect-error - bypassing private modifier
+    game.tick = game.MAX_TICKS - 1;
+    game.nextTick();
+
+    expect(game.status).toBe(GameStatus.FINISHED);
+    const result = game.checkGameEnd();
+    expect(result).toEqual({ mode: GameMode.TURF_WAR, winnerTeamId: "t1" });
+  });
+
+  it("integrates with RespawningCombatResolver during action execution", () => {
+    const grid = createGridForTurfWar();
+    const game = new TurfWarGame(grid);
+    const t1 = new StandardTeam("t1");
+    const t2 = new StandardTeam("t2");
+    const p1 = new Player(t1, "p1", PlayerStatus.ACTIVE);
+    const p2 = new Player(t2, "p2", PlayerStatus.ACTIVE);
+    game.players.set(p1.playerId, p1);
+    game.players.set(p2.playerId, p2);
+
+    const c0 = grid.get({ x: 0, y: 0 })!;
+    const c1 = grid.get({ x: 1, y: 0 })!;
+    const c2 = grid.get({ x: 2, y: 0 })!;
+
+    c0.owner = p1;
+    c0.troopCount = 10;
+
+    c1.owner = p2;
+    c1.troopCount = 2;
+
+    // Give p2 another tile so they respawn
+    c2.owner = p2;
+    c2.troopCount = 5;
+
+    game.startGame();
+
+    // p1 attacks p2's general
+    const success = game.handleAction(createMoveAction("p1"));
+
+    expect(success).toBe(true);
+
+    // Attack succeeded, p1 owns c1 and it became a CITY
+    expect(c1.owner).toBe(p1);
+    expect(c1.terrain).toBe(Terrain.CITY);
+
+    // p2 respawns general on c2
+    expect(c2.owner).toBe(p2);
+    expect(c2.terrain).toBe(Terrain.GENERAL);
+    expect(p2.status).toBe(PlayerStatus.ACTIVE);
+
+    // Game should still be playing
+    expect(game.status).toBe(GameStatus.PLAYING);
+  });
+});


### PR DESCRIPTION
Closes #70 .

This pull request introduces the new `TurfWarGame` mode to the engine, implementing its core game logic, integration, and comprehensive test coverage. The main changes include the creation of the `TurfWarGame` class with its specific rules, its export in the module interface, and a suite of tests to ensure correct behavior for win conditions, combat integration, and scoring.

**TurfWarGame mode implementation:**

* Added the `TurfWarGame` class in `turf-war-game.ts`, implementing unique rules such as double troop generation, win conditions based on team survival or land control after a time limit, and special handling for neutralized generals.
* Registered the new `TurfWarGame` in the engine's public API by exporting it in `index.ts`.

**Test coverage:**

* Added a comprehensive test suite in `turf-war-game.test.ts` to verify win conditions (single team remaining, time limit with most land), correct integration with `RespawningCombatResolver`, and correct tile/terrain transitions.