### PR TITLE
feat(game): add clear move queue functionality and keyboard shortcut

### DIFF
--- a/apps/client/src/features/game/api/use-game-room.ts
+++ b/apps/client/src/features/game/api/use-game-room.ts
@@ -11,7 +11,7 @@ import {
   MatchClientMessage,
   MatchServerMessage,
 } from "@generals-plus/shared-types";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { RenderGrid } from "#/features/game/renderer/render-grid";
 import { createRenderGrid } from "#/features/game/utils/grid-adapter";
@@ -443,21 +443,22 @@ export function useGameRoom(
     };
   }, [connection, source]);
 
-  const sendMove = (from: ICoordinate, to: ICoordinate) => {
-    if (!room) return;
-    room.send(MatchClientMessage.ACTION, {
-      playerId: room.sessionId,
-      type: ActionType.MOVE,
-      from,
-      to,
-    });
-  };
+  const sendMove = useCallback(
+    (from: ICoordinate, to: ICoordinate) => {
+      room?.send(MatchClientMessage.ACTION, {
+        playerId: room.sessionId,
+        type: ActionType.MOVE,
+        from,
+        to,
+      });
+    },
+    [room],
+  );
 
-  const clearMoveQueue = () => {
-    if (!room) return;
+  const clearMoveQueue = useCallback(() => {
     setMoveQueue([]);
-    room.send(MatchClientMessage.CLEAR_QUEUE);
-  };
+    room?.send(MatchClientMessage.CLEAR_QUEUE);
+  }, [room]);
 
   return {
     room,

--- a/apps/client/src/features/game/api/use-game-room.ts
+++ b/apps/client/src/features/game/api/use-game-room.ts
@@ -445,7 +445,8 @@ export function useGameRoom(
 
   const sendMove = useCallback(
     (from: ICoordinate, to: ICoordinate) => {
-      room?.send(MatchClientMessage.ACTION, {
+      if (!room) return;
+      room.send(MatchClientMessage.ACTION, {
         playerId: room.sessionId,
         type: ActionType.MOVE,
         from,

--- a/apps/client/src/features/game/api/use-game-room.ts
+++ b/apps/client/src/features/game/api/use-game-room.ts
@@ -310,7 +310,7 @@ function isReadyMatchState(state: MatchState) {
  * The hook consumes a seat reservation or restores a persisted recovery token,
  * subscribes to authoritative match state, adapts the current client's vision
  * schema into a render grid, mirrors the player's server-side action queue for
- * the movement overlay, and exposes a typed `sendMove` command for user input.
+ * the movement overlay, and exposes typed queue commands for user input.
  */
 export function useGameRoom(
   connection: GameRoomConnection,
@@ -453,6 +453,12 @@ export function useGameRoom(
     });
   };
 
+  const clearMoveQueue = () => {
+    if (!room) return;
+    setMoveQueue([]);
+    room.send(MatchClientMessage.CLEAR_QUEUE);
+  };
+
   return {
     room,
     renderGrid,
@@ -460,6 +466,7 @@ export function useGameRoom(
     gameState,
     gameResult,
     sendMove,
+    clearMoveQueue,
     playerColors,
     playerNames,
     connectionStatus,

--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -98,6 +98,7 @@ export function GamePage({ connection, source }: GamePageProps) {
     gameState,
     gameResult,
     sendMove,
+    clearMoveQueue,
     playerColors,
     playerNames,
     connectionStatus,
@@ -195,6 +196,7 @@ export function GamePage({ connection, source }: GamePageProps) {
         moveQueue={moveQueue}
         onSelectCell={handleSelectCell}
         onQueueMove={handleQueueMove}
+        onClearMoveQueue={clearMoveQueue}
         playerColors={playerColors}
       />
 

--- a/apps/client/src/features/game/renderer/game-app.tsx
+++ b/apps/client/src/features/game/renderer/game-app.tsx
@@ -9,7 +9,7 @@ import type { RenderGrid } from "#/features/game/renderer/render-grid";
 import { TerrainTheme } from "#/features/game/renderer/theme.ts";
 import { Viewport } from "#/features/game/renderer/viewport";
 import type { MoveDirection, MoveIntent } from "#/features/game/utils/move";
-import { KeyToDirection } from "#/features/game/utils/move";
+import { ClearMoveQueueKey, KeyToDirection } from "#/features/game/utils/move";
 import { cn } from "#/lib/utils";
 
 interface GameAppProps {
@@ -19,6 +19,7 @@ interface GameAppProps {
   readonly moveQueue: MoveIntent[];
   readonly onSelectCell: (coord: ICoordinate) => void;
   readonly onQueueMove: (direction: MoveDirection) => void;
+  readonly onClearMoveQueue: () => void;
   readonly playerColors: Map<string, number>;
   readonly className?: string;
 }
@@ -35,6 +36,7 @@ export function GameApp({
   moveQueue,
   onSelectCell,
   onQueueMove,
+  onClearMoveQueue,
   playerColors,
   className,
 }: GameAppProps) {
@@ -60,6 +62,12 @@ export function GameApp({
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const key = e.key.toLowerCase();
+      if (key === ClearMoveQueueKey) {
+        e.preventDefault();
+        onClearMoveQueue();
+        return;
+      }
+
       if (KeyToDirection[key]) {
         e.preventDefault();
         onQueueMove(KeyToDirection[key]);
@@ -68,7 +76,7 @@ export function GameApp({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [onQueueMove]);
+  }, [onClearMoveQueue, onQueueMove]);
 
   return (
     <div ref={containerRef} className={cn("h-full w-full", className)}>

--- a/apps/client/src/features/game/utils/move.ts
+++ b/apps/client/src/features/game/utils/move.ts
@@ -24,6 +24,8 @@ export const KeyToDirection: Record<string, MoveDirection> = {
   arrowright: MoveDirection.RIGHT,
 } as const;
 
+export const ClearMoveQueueKey = "q";
+
 export function getTargetCoord(move: MoveIntent): ICoordinate {
   switch (move.direction) {
     case MoveDirection.UP:

--- a/apps/client/tests/features/game/renderer/game-app.test.tsx
+++ b/apps/client/tests/features/game/renderer/game-app.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GameApp } from "#/features/game/renderer/game-app";
+import type { RenderGrid } from "#/features/game/renderer/render-grid";
+
+vi.mock("@pixi/react", () => ({
+  Application: ({ children }: { children: ReactNode }) => (
+    <div data-testid="pixi-app">{children}</div>
+  ),
+}));
+
+vi.mock("pixi.js", () => ({
+  Assets: {
+    load: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("#/features/game/renderer/map-renderer", () => ({
+  MapRenderer: () => <div data-testid="map-renderer" />,
+}));
+
+vi.mock("#/features/game/renderer/viewport", () => ({
+  Viewport: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+function renderGameApp(overrides: Partial<Parameters<typeof GameApp>[0]> = {}) {
+  return render(
+    <GameApp
+      grid={{ width: 2, height: 2 } as RenderGrid}
+      selection={null}
+      moveQueue={[]}
+      onSelectCell={vi.fn()}
+      onQueueMove={vi.fn()}
+      onClearMoveQueue={vi.fn()}
+      playerColors={new Map()}
+      {...overrides}
+    />,
+  );
+}
+
+describe("GameApp keyboard input", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("clears the move queue when q is pressed", () => {
+    const onQueueMove = vi.fn();
+    const onClearMoveQueue = vi.fn();
+
+    renderGameApp({ onQueueMove, onClearMoveQueue });
+
+    fireEvent.keyDown(window, { key: "q" });
+
+    expect(onClearMoveQueue).toHaveBeenCalledTimes(1);
+    expect(onQueueMove).not.toHaveBeenCalled();
+  });
+});

--- a/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
+++ b/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
@@ -3,6 +3,7 @@
 import { GameMode } from "@generals-plus/engine";
 import type { SetupSettings } from "@generals-plus/shared-types";
 import {
+  MatchClientMessage,
   MatchServerMessage,
   PLAYER_COLOR_PALETTE,
   QueueClientMessage,
@@ -44,7 +45,11 @@ vi.mock("#/infra/network/provider", () => ({
 }));
 
 vi.mock("#/features/game/renderer/game-app", () => ({
-  GameApp: () => <div data-testid="game-app" />,
+  GameApp: ({ onClearMoveQueue }: { onClearMoveQueue: () => void }) => (
+    <button data-testid="game-app" type="button" onClick={onClearMoveQueue}>
+      Game app
+    </button>
+  ),
 }));
 
 function auth() {
@@ -611,6 +616,46 @@ describe("client room flows", () => {
     });
 
     expect(matchRoom.leave).not.toHaveBeenCalled();
+  });
+
+  it("sends a clear-queue message from the match input surface", async () => {
+    const setupRoom = createRoom({
+      roomId: "setup-clear-queue",
+      state: createSetupState([
+        {
+          id: "player-1",
+          displayName: "Nova",
+          color: PLAYER_COLOR_PALETTE[0],
+          isHost: true,
+        },
+        {
+          id: "player-2",
+          displayName: "Rook",
+          color: PLAYER_COLOR_PALETTE[1],
+          isHost: false,
+        },
+      ]),
+    });
+    const matchRoom = createRoom({
+      roomId: "match-clear-queue",
+      state: createMatchState(),
+    });
+    const reservation = {
+      name: ROOM_NAMES.MATCH,
+      roomId: "match-clear-queue",
+      sessionId: "session-1",
+    };
+    networkMocks.joinById.mockResolvedValue(setupRoom);
+    networkMocks.consumeSeatReservation.mockResolvedValue(matchRoom);
+
+    renderRoute("/match/setup-clear-queue", auth());
+
+    await screen.findByText("You are host");
+    setupRoom.emitMessage(SetupServerMessage.SEAT_RESERVATION, reservation);
+
+    fireEvent.click(await screen.findByTestId("game-app"));
+
+    expect(matchRoom.send).toHaveBeenCalledWith(MatchClientMessage.CLEAR_QUEUE);
   });
 
   it("restores an official match after refreshing on the root route", async () => {


### PR DESCRIPTION
Closes #69.

This pull request adds a new feature that allows players to clear their move queue with a keyboard shortcut (`q`) and exposes this functionality throughout the client, including keyboard handling and tests. The implementation includes updates to the game room API, renderer, and tests to ensure the clear queue command is properly sent to the server and handled in the UI.

**New Move Queue Clearing Feature**

- Added a `clearMoveQueue` function to `useGameRoom`, which clears the local move queue and sends a `CLEAR_QUEUE` message to the server.
- Exposed `clearMoveQueue` as a prop to the `GameApp` component, and ensured it's passed through all relevant layers (`GamePage`, `GameApp`). [[1]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29R101) [[2]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29R199) [[3]](diffhunk://#diff-302d62eeb0e36daa704c64b99a0fafbd85e33a05ff0f0e4a098201953a6e0725R22) [[4]](diffhunk://#diff-302d62eeb0e36daa704c64b99a0fafbd85e33a05ff0f0e4a098201953a6e0725R39)

**Keyboard Shortcut Integration**

- Introduced a keyboard handler in `GameApp` so that pressing the `q` key triggers the move queue to clear, using the new `ClearMoveQueueKey` constant. [[1]](diffhunk://#diff-302d62eeb0e36daa704c64b99a0fafbd85e33a05ff0f0e4a098201953a6e0725R65-R70) [[2]](diffhunk://#diff-302d62eeb0e36daa704c64b99a0fafbd85e33a05ff0f0e4a098201953a6e0725L71-R79) [[3]](diffhunk://#diff-1ffd56e844ab9837441ade7eb47b3d2f3acc2ffb64fb45a5cf3c98c59299c8cdR27-R28)

**Testing**

- Added a unit test for `GameApp` to verify that pressing `q` calls the `onClearMoveQueue` handler.
- Updated integration tests to simulate the clear queue action and verify the correct client-server message is sent. [[1]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fR6) [[2]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fL47-R52) [[3]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fR621-R660)

These changes improve the player's control over their move queue, provide keyboard accessibility, and ensure robust coverage with new and updated tests.