### PR TITLE
refactor(server, engine): move grid generation to engine

### DIFF
--- a/apps/server/src/features/game/utils.ts
+++ b/apps/server/src/features/game/utils.ts
@@ -1,7 +1,6 @@
-import type { GridGeneratorOptions, IBaseGame } from "@generals-plus/engine";
+import type { GridInput, IBaseGame } from "@generals-plus/engine";
 import {
   ClassicGame,
-  DefaultGridGenerator,
   GameMode,
   Player,
   StandardTeam,
@@ -9,7 +8,7 @@ import {
 
 export interface CreateGameOptions {
   mode: GameMode;
-  gridOptions?: GridGeneratorOptions;
+  gridOptions?: GridInput;
   playerIds: string[];
   playerPerTeam: number;
 }
@@ -21,11 +20,9 @@ export interface CreateGameOptions {
  * @throws Error if the GameMode has no implementation yet.
  */
 export function createGame(options: CreateGameOptions): IBaseGame {
-  const grid = new DefaultGridGenerator().generate(options.gridOptions);
-
   switch (options.mode) {
     case GameMode.CLASSIC: {
-      const game = new ClassicGame(grid);
+      const game = new ClassicGame(options.gridOptions ?? {});
 
       const teamsCount = Math.ceil(
         options.playerIds.length / options.playerPerTeam,

--- a/packages/engine/src/domain/combat/base-combat-resolver.ts
+++ b/packages/engine/src/domain/combat/base-combat-resolver.ts
@@ -14,7 +14,7 @@ import type { IPlayer } from "#/domain/player/interfaces";
  * - Leaves the general capture behavior to subclasses.
  */
 export abstract class BaseCombatResolver implements CombatResolver {
-  public execute(
+  execute(
     action: MoveAction,
     grid: IGrid,
     players: Map<string, IPlayer>,

--- a/packages/engine/src/domain/game/base-game.ts
+++ b/packages/engine/src/domain/game/base-game.ts
@@ -121,7 +121,7 @@ export abstract class BaseGame implements IBaseGame {
 
   protected cachedGameResult: IGameResult | null = null;
 
-  public checkGameEnd(): IGameResult | null {
+  checkGameEnd(): IGameResult | null {
     if (this.status !== GameStatus.PLAYING) {
       return this.cachedGameResult;
     }
@@ -136,7 +136,7 @@ export abstract class BaseGame implements IBaseGame {
 
   protected abstract evaluateGameEnd(): IGameResult | null;
 
-  public forceEnd(): IGameResult {
+  forceEnd(): IGameResult {
     this.status = GameStatus.FINISHED;
     this.cachedGameResult = { mode: this.mode, winnerTeamId: null };
     return this.cachedGameResult;

--- a/packages/engine/src/domain/game/base-game.ts
+++ b/packages/engine/src/domain/game/base-game.ts
@@ -7,6 +7,8 @@ import type { GameMode } from "#/domain/game/game-mode";
 import type { IGameResult } from "#/domain/game/game-result";
 import { GameStatus } from "#/domain/game/game-status";
 import type { IBaseGame, IBaseScoreboard } from "#/domain/game/interfaces";
+import type { GridInput } from "#/domain/grid/grid-generator";
+import { DefaultGridGenerator, isGrid } from "#/domain/grid/grid-generator";
 import type { IGrid } from "#/domain/grid/interfaces";
 import type { IItem } from "#/domain/item/interfaces";
 import type { IPlayer, IPlayerState } from "#/domain/player/interfaces";
@@ -32,8 +34,10 @@ export abstract class BaseGame implements IBaseGame {
   readonly effectRegistry = new EffectRegistry();
   protected readonly visibilityMap: VisibilityMap;
 
-  constructor(grid: IGrid) {
-    this.grid = grid;
+  constructor(input: GridInput) {
+    this.grid = isGrid(input)
+      ? input
+      : new DefaultGridGenerator().generate(input);
     this.visibilityMap = new VisibilityMap(this.grid);
   }
 

--- a/packages/engine/src/domain/game/domination-game.ts
+++ b/packages/engine/src/domain/game/domination-game.ts
@@ -15,11 +15,11 @@ import type {
 import { PlayerStatus } from "#/domain/player/player-status";
 
 export class DominationGame extends BaseGame implements IDominationGame {
-  public readonly mode = GameMode.DOMINATION;
+  readonly mode = GameMode.DOMINATION;
   private readonly combatResolver = new StandardCombatResolver();
 
-  public readonly targetScore: number = 1000;
-  public readonly teamScores = new Map<string, number>();
+  readonly targetScore: number = 1000;
+  readonly teamScores = new Map<string, number>();
 
   private readonly MAX_TICKS = 600; // 5 minutes
   private readonly flagHoldState = new Map<
@@ -27,7 +27,7 @@ export class DominationGame extends BaseGame implements IDominationGame {
     { teamId: string; ticks: number }
   >();
 
-  public startGame(): void {
+  startGame(): void {
     super.startGame();
     this.assignStartPositions(Terrain.CITY); // Start positions are normal cities
 
@@ -99,7 +99,7 @@ export class DominationGame extends BaseGame implements IDominationGame {
     }
   }
 
-  public nextTick(): void {
+  nextTick(): void {
     if (this.status !== GameStatus.PLAYING) {
       return;
     }
@@ -166,7 +166,7 @@ export class DominationGame extends BaseGame implements IDominationGame {
     return null;
   }
 
-  public getScoreboard(): IDominationScoreboard {
+  getScoreboard(): IDominationScoreboard {
     const baseScores = this.calculateBaseScores();
     const players = Array.from(baseScores.entries()).map(
       ([playerId, score]) => ({

--- a/packages/engine/src/domain/game/turf-war-game.ts
+++ b/packages/engine/src/domain/game/turf-war-game.ts
@@ -16,11 +16,11 @@ import type {
 import { PlayerStatus } from "#/domain/player/player-status";
 
 export class TurfWarGame extends BaseGame implements ITurfWarGame {
-  public readonly mode = GameMode.TURF_WAR;
+  readonly mode = GameMode.TURF_WAR;
   private readonly combatResolver = new RespawningCombatResolver();
   private readonly MAX_TICKS = 360; // 3 minutes at 2 ticks/sec
 
-  public startGame(): void {
+  startGame(): void {
     super.startGame();
     this.assignStartPositions();
 
@@ -79,7 +79,7 @@ export class TurfWarGame extends BaseGame implements ITurfWarGame {
     return success;
   }
 
-  public nextTick(): void {
+  nextTick(): void {
     if (this.status !== GameStatus.PLAYING) {
       return;
     }
@@ -135,7 +135,7 @@ export class TurfWarGame extends BaseGame implements ITurfWarGame {
     return null;
   }
 
-  public getScoreboard(): ITurfWarScoreboard {
+  getScoreboard(): ITurfWarScoreboard {
     const baseScores = this.calculateBaseScores();
     const players = Array.from(baseScores.entries()).map(
       ([playerId, score]) => ({

--- a/packages/engine/src/domain/grid/grid-generator.ts
+++ b/packages/engine/src/domain/grid/grid-generator.ts
@@ -115,8 +115,18 @@ export type GridInput = IGrid | GridGeneratorOptions;
  * Type guard to check if a GridInput is a pre-built IGrid.
  */
 export function isGrid(input: GridInput): input is IGrid {
+  if (typeof input !== "object" || input === null) {
+    return false;
+  }
+
+  const candidate = input as Record<string, unknown>;
+
   return (
-    typeof (input as Record<string, unknown>)["forEachTerrain"] === "function"
+    typeof candidate["width"] === "number" &&
+    typeof candidate["height"] === "number" &&
+    typeof candidate["get"] === "function" &&
+    typeof candidate["forEach"] === "function" &&
+    typeof candidate["forEachTerrain"] === "function"
   );
 }
 

--- a/packages/engine/src/domain/grid/grid-generator.ts
+++ b/packages/engine/src/domain/grid/grid-generator.ts
@@ -106,6 +106,20 @@ export interface GridGenerator {
   generate(options?: GridGeneratorOptions): IGrid;
 }
 
+/**
+ * Union type representing either a pre-built grid or generation options.
+ */
+export type GridInput = IGrid | GridGeneratorOptions;
+
+/**
+ * Type guard to check if a GridInput is a pre-built IGrid.
+ */
+export function isGrid(input: GridInput): input is IGrid {
+  return (
+    typeof (input as Record<string, unknown>)["forEachTerrain"] === "function"
+  );
+}
+
 // ── Resolved config (all fields required) ────────────────────────────
 
 interface ResolvedConfig {


### PR DESCRIPTION
Closes #78 .

This pull request refactors how grid data is passed and handled when creating a new game. Instead of always generating a grid from options, the code now supports passing in either a pre-built grid or generation options, improving flexibility and code reuse. The most important changes are grouped below:

**Grid Input Handling Improvements:**

* Introduced a new `GridInput` type, allowing either a pre-built `IGrid` or grid generation options (`GridGeneratorOptions`) to be passed where a grid is needed. Added a type guard function `isGrid` to distinguish between these types (`GridInput`, `isGrid`, `grid-generator.ts`).
* Updated the `BaseGame` class constructor to accept a `GridInput` and use the `isGrid` type guard to determine whether to use the input directly or generate a new grid (`base-game.ts`).

**Game Creation Logic Updates:**

* Changed the `createGame` function and related types to use `GridInput` instead of only grid generation options, and updated the instantiation of `ClassicGame` to pass the new `GridInput` directly (`utils.ts`). [[1]](diffhunk://#diff-b4e5c1b8d7fcb96b9d8a864c026862b18dad1976d29aaadf265f48ae1ec4cd68L1-R11) [[2]](diffhunk://#diff-b4e5c1b8d7fcb96b9d8a864c026862b18dad1976d29aaadf265f48ae1ec4cd68L24-R25)

**Imports and Type Adjustments:**

* Updated imports in relevant files to use the new `GridInput` type and related helpers (`base-game.ts`, `utils.ts`). [[1]](diffhunk://#diff-81f1e2712e34dc741a2a712ef67ac6891ed6e1f2b214a0a13a5cd5df4c9a23d9R10-R11) [[2]](diffhunk://#diff-b4e5c1b8d7fcb96b9d8a864c026862b18dad1976d29aaadf265f48ae1ec4cd68L1-R11)

These changes make the game creation process more flexible and simplify how grids are handled throughout the codebase.