### PR TITLE
feat(engine/turf-war): add team land percent

### DIFF
--- a/packages/engine/src/domain/game/interfaces.ts
+++ b/packages/engine/src/domain/game/interfaces.ts
@@ -132,6 +132,11 @@ export interface ITurfWarScoreboard extends IBaseScoreboard {
     readonly troops: number;
     readonly land: number;
   }>;
+  readonly teams: Array<{
+    readonly teamId: string;
+    readonly playerIds: readonly string[];
+    readonly landPercent: number;
+  }>;
 }
 
 export interface IDominationScoreboard extends IBaseScoreboard {

--- a/packages/engine/src/domain/game/turf-war-game.ts
+++ b/packages/engine/src/domain/game/turf-war-game.ts
@@ -145,9 +145,36 @@ export class TurfWarGame extends BaseGame implements ITurfWarGame {
       }),
     );
 
+    const teamLand = new Map<string, number>();
+    let capturableTotal = 0;
+    this.grid.forEach((cell) => {
+      if (cell.terrain !== Terrain.MOUNTAIN && cell.terrain !== Terrain.VOID) {
+        capturableTotal++;
+        if (cell.owner) {
+          const player = this.players.get(cell.owner.playerId);
+          if (player) {
+            const teamId = player.team.teamId;
+            teamLand.set(teamId, (teamLand.get(teamId) ?? 0) + 1);
+          }
+        }
+      }
+    });
+
+    const teams = Array.from(this.teams.values()).map((team) => ({
+      teamId: team.teamId,
+      playerIds: team.players.map((p) => p.playerId),
+      landPercent:
+        capturableTotal > 0
+          ? Math.round(
+              ((teamLand.get(team.teamId) ?? 0) / capturableTotal) * 100,
+            )
+          : 0,
+    }));
+
     return {
       mode: this.mode,
       players,
+      teams,
     };
   }
 

--- a/packages/engine/tests/domain/game/turf-war-game.test.ts
+++ b/packages/engine/tests/domain/game/turf-war-game.test.ts
@@ -78,6 +78,46 @@ describe("TurfWarGame", () => {
     expect(result).toEqual({ mode: GameMode.TURF_WAR, winnerTeamId: "t1" });
   });
 
+  describe("getScoreboard", () => {
+    it("returns team landPercent and playerIds", () => {
+      const grid = new Grid(4, 1, [
+        [
+          new Cell({ coordinate: { x: 0, y: 0 }, terrain: Terrain.GENERAL }),
+          new Cell({ coordinate: { x: 1, y: 0 }, terrain: Terrain.PLAIN }),
+          new Cell({ coordinate: { x: 2, y: 0 }, terrain: Terrain.MOUNTAIN }),
+          new Cell({ coordinate: { x: 3, y: 0 }, terrain: Terrain.GENERAL }),
+        ],
+      ]);
+      const game = new TurfWarGame(grid);
+      const t1 = new StandardTeam("t1");
+      const t2 = new StandardTeam("t2");
+      const p1 = new Player(t1, "p1", PlayerStatus.ACTIVE);
+      const p2 = new Player(t2, "p2", PlayerStatus.ACTIVE);
+      t1.addPlayer(p1);
+      t2.addPlayer(p2);
+      game.teams.set("t1", t1);
+      game.teams.set("t2", t2);
+      game.players.set(p1.playerId, p1);
+      game.players.set(p2.playerId, p2);
+
+      grid.get({ x: 0, y: 0 })!.owner = p1;
+      grid.get({ x: 1, y: 0 })!.owner = p1;
+      grid.get({ x: 3, y: 0 })!.owner = p2;
+
+      game.startGame();
+
+      const scoreboard = game.getScoreboard();
+      // 3 capturable tiles (excludes MOUNTAIN at x:2), t1 owns 2 → 67%, t2 owns 1 → 33%
+      const t1Entry = scoreboard.teams.find((t) => t.teamId === "t1")!;
+      const t2Entry = scoreboard.teams.find((t) => t.teamId === "t2")!;
+
+      expect(t1Entry.playerIds).toEqual(["p1"]);
+      expect(t1Entry.landPercent).toBe(67);
+      expect(t2Entry.playerIds).toEqual(["p2"]);
+      expect(t2Entry.landPercent).toBe(33);
+    });
+  });
+
   it("integrates with RespawningCombatResolver during action execution", () => {
     const grid = createGridForTurfWar();
     const game = new TurfWarGame(grid);


### PR DESCRIPTION
Closes #82 .

This pull request enhances the Turf War game mode by adding team-based statistics to the scoreboard, specifically tracking the percentage of land controlled by each team and the players on each team. It also introduces corresponding tests to ensure the new functionality works as intended.

**Scoreboard Enhancements:**

- The `ITurfWarScoreboard` interface now includes a `teams` array, where each entry contains the `teamId`, a list of `playerIds`, and the `landPercent` representing the percentage of capturable land owned by the team.
- The `TurfWarGame.getScoreboard` method calculates the percentage of capturable land owned by each team and returns this information along with the player IDs for each team.

**Testing Improvements:**

- Added a unit test to verify that the scoreboard correctly reports each team's `landPercent` and `playerIds` based on the current state of the grid and team assignments.