### PR TITLE
test(server): test for user repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ build
 *.njsproj
 *.sln
 *.sw?
+
+coverage/

--- a/apps/server/tests/infra/db/repositories/MongoUserRepository.test.ts
+++ b/apps/server/tests/infra/db/repositories/MongoUserRepository.test.ts
@@ -1,6 +1,7 @@
 import { GameMode } from "@generals-plus/engine";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { IUserDocument } from "#/infra/db/models/user-model";
 import { UserModel } from "#/infra/db/models/user-model";
 import { MongoUserRepository } from "#/infra/db/repositories/MongoUserRepository";
 
@@ -64,7 +65,7 @@ describe("MongoUserRepository and UserModel tests", () => {
 
         const findOneSpy = vi.spyOn(UserModel, "findOne").mockReturnValue({
           exec: vi.fn().mockResolvedValue(mockDoc),
-        } as any);
+        } as unknown as never);
 
         const result = await repository.findByEmail("found@example.com");
 
@@ -83,7 +84,7 @@ describe("MongoUserRepository and UserModel tests", () => {
       it("should return null when user is not found", async () => {
         const findOneSpy = vi.spyOn(UserModel, "findOne").mockReturnValue({
           exec: vi.fn().mockResolvedValue(null),
-        } as any);
+        } as unknown as never);
 
         const result = await repository.findByEmail("notfound@example.com");
 
@@ -106,12 +107,12 @@ describe("MongoUserRepository and UserModel tests", () => {
           ratings: { classic: 1000 },
         };
 
-        let savedInstance: any = null;
+        let savedInstance: IUserDocument | null = null;
         const saveSpy = vi
           .spyOn(UserModel.prototype, "save")
-          .mockImplementation(function (this: any) {
+          .mockImplementation(function (this: IUserDocument) {
             savedInstance = this;
-            return Promise.resolve(mockSavedDoc as any);
+            return Promise.resolve(mockSavedDoc as unknown as IUserDocument);
           });
 
         const result = await repository.createWithEmailAndPassword(
@@ -129,10 +130,10 @@ describe("MongoUserRepository and UserModel tests", () => {
         expect(saveSpy).toHaveBeenCalled();
         expect(savedInstance).toBeDefined();
         // Check that options sanitization worked:
-        expect(savedInstance.email).toBe("new@example.com"); // constructor override parameter
-        expect(savedInstance.displayName).toBe("New User"); // safe option
-        expect(savedInstance.anonymous).toBe(false); // set to false directly
-        expect(savedInstance.verified).toBe(false); // set to false directly
+        expect(savedInstance?.email).toBe("new@example.com"); // constructor override parameter
+        expect(savedInstance?.displayName).toBe("New User"); // safe option
+        expect(savedInstance?.anonymous).toBe(false); // set to false directly
+        expect(savedInstance?.verified).toBe(false); // set to false directly
 
         expect(result).toEqual({
           id: "60f7c1234567890123456789",
@@ -155,12 +156,12 @@ describe("MongoUserRepository and UserModel tests", () => {
           ratings: { classic: 1000 },
         };
 
-        let savedInstance: any = null;
+        let savedInstance: IUserDocument | null = null;
         const saveSpy = vi
           .spyOn(UserModel.prototype, "save")
-          .mockImplementation(function (this: any) {
+          .mockImplementation(function (this: IUserDocument) {
             savedInstance = this;
-            return Promise.resolve(mockSavedDoc as any);
+            return Promise.resolve(mockSavedDoc as unknown as IUserDocument);
           });
 
         const result = await repository.createAnonymous({
@@ -171,9 +172,9 @@ describe("MongoUserRepository and UserModel tests", () => {
 
         expect(saveSpy).toHaveBeenCalled();
         expect(savedInstance).toBeDefined();
-        expect(savedInstance.displayName).toBe("Guest User");
-        expect(savedInstance.anonymous).toBe(true);
-        expect(savedInstance.verified).toBe(false);
+        expect(savedInstance?.displayName).toBe("Guest User");
+        expect(savedInstance?.anonymous).toBe(true);
+        expect(savedInstance?.verified).toBe(false);
 
         expect(result).toEqual({
           id: "60f7c123456789012345678a",
@@ -194,7 +195,7 @@ describe("MongoUserRepository and UserModel tests", () => {
             acknowledged: true,
             matchedCount: 1,
           }),
-        } as any);
+        } as unknown as never);
 
         const result = await repository.updatePassword(
           "test@example.com",
@@ -214,7 +215,7 @@ describe("MongoUserRepository and UserModel tests", () => {
             acknowledged: true,
             matchedCount: 0,
           }),
-        } as any);
+        } as unknown as never);
 
         const result = await repository.updatePassword(
           "missing@example.com",
@@ -235,7 +236,7 @@ describe("MongoUserRepository and UserModel tests", () => {
           exec: vi.fn().mockResolvedValue({
             modifiedCount: 1,
           }),
-        } as any);
+        } as unknown as never);
 
         const result = await repository.verifyEmail("test@example.com");
 
@@ -251,7 +252,7 @@ describe("MongoUserRepository and UserModel tests", () => {
           exec: vi.fn().mockResolvedValue({
             modifiedCount: 0,
           }),
-        } as any);
+        } as unknown as never);
 
         const result = await repository.verifyEmail(
           "already-verified@example.com",
@@ -274,7 +275,7 @@ describe("MongoUserRepository and UserModel tests", () => {
 
         const findByIdSpy = vi.spyOn(UserModel, "findById").mockReturnValue({
           exec: vi.fn().mockResolvedValue(mockUser),
-        } as any);
+        } as unknown as never);
 
         const rating = await repository.getRating(
           "60f7c1234567890123456789",
@@ -293,7 +294,7 @@ describe("MongoUserRepository and UserModel tests", () => {
 
         const findByIdSpy = vi.spyOn(UserModel, "findById").mockReturnValue({
           exec: vi.fn().mockResolvedValue(mockUser),
-        } as any);
+        } as unknown as never);
 
         const rating = await repository.getRating(
           "60f7c1234567890123456789",
@@ -307,7 +308,7 @@ describe("MongoUserRepository and UserModel tests", () => {
       it("should return default rating 1000 if user is not found", async () => {
         const findByIdSpy = vi.spyOn(UserModel, "findById").mockReturnValue({
           exec: vi.fn().mockResolvedValue(null),
-        } as any);
+        } as unknown as never);
 
         const rating = await repository.getRating(
           "missing-id",
@@ -323,7 +324,7 @@ describe("MongoUserRepository and UserModel tests", () => {
       it("should call bulkWrite with the formatted updates", async () => {
         const bulkWriteSpy = vi
           .spyOn(UserModel, "bulkWrite")
-          .mockResolvedValue({} as any);
+          .mockResolvedValue({} as unknown as never);
 
         const updates = [
           { userId: "user1", mode: GameMode.CLASSIC, newRating: 1050 },

--- a/apps/server/tests/infra/db/repositories/MongoUserRepository.test.ts
+++ b/apps/server/tests/infra/db/repositories/MongoUserRepository.test.ts
@@ -1,0 +1,352 @@
+import { GameMode } from "@generals-plus/engine";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UserModel } from "#/infra/db/models/user-model";
+import { MongoUserRepository } from "#/infra/db/repositories/MongoUserRepository";
+
+describe("MongoUserRepository and UserModel tests", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("UserModel Schema Defaults and Validation (Offline)", () => {
+    it("should populate correct defaults for ratings and boolean flags", async () => {
+      const user = new UserModel({
+        email: "test@example.com",
+        password: "hashedpassword",
+        displayName: "Test User",
+      });
+
+      // Mongoose built-in offline validation
+      await user.validate();
+
+      expect(user.anonymous).toBe(false);
+      expect(user.verified).toBe(false);
+      expect(user.ratings).toBeDefined();
+      expect(user.ratings.classic).toBe(1000);
+      expect(user.ratings.demolition).toBe(1000);
+      expect(user.ratings.turf_war).toBe(1000);
+      expect(user.ratings.biohazard).toBe(1000);
+      expect(user.ratings.payload).toBe(1000);
+      expect(user.ratings.rugby).toBe(1000);
+      expect(user.ratings.collapse).toBe(1000);
+      expect(user.ratings.domination).toBe(1000);
+      expect(user.ratings.espionage).toBe(1000);
+    });
+
+    it("should trim email and displayName", async () => {
+      const user = new UserModel({
+        email: "  test@example.com  ",
+        displayName: "  Test User  ",
+      });
+
+      await user.validate();
+
+      expect(user.email).toBe("test@example.com");
+      expect(user.displayName).toBe("Test User");
+    });
+  });
+
+  describe("MongoUserRepository Operations", () => {
+    const repository = new MongoUserRepository();
+
+    describe("findByEmail", () => {
+      it("should return the mapped user entity when user is found", async () => {
+        const mockDoc = {
+          _id: "60f7c1234567890123456789",
+          email: "found@example.com",
+          password: "hash",
+          displayName: "Found User",
+          anonymous: false,
+          verified: true,
+          ratings: { classic: 1200 },
+        };
+
+        const findOneSpy = vi.spyOn(UserModel, "findOne").mockReturnValue({
+          exec: vi.fn().mockResolvedValue(mockDoc),
+        } as any);
+
+        const result = await repository.findByEmail("found@example.com");
+
+        expect(findOneSpy).toHaveBeenCalledWith({ email: "found@example.com" });
+        expect(result).toEqual({
+          id: "60f7c1234567890123456789",
+          email: "found@example.com",
+          password: "hash",
+          displayName: "Found User",
+          anonymous: false,
+          verified: true,
+          ratings: { classic: 1200 },
+        });
+      });
+
+      it("should return null when user is not found", async () => {
+        const findOneSpy = vi.spyOn(UserModel, "findOne").mockReturnValue({
+          exec: vi.fn().mockResolvedValue(null),
+        } as any);
+
+        const result = await repository.findByEmail("notfound@example.com");
+
+        expect(findOneSpy).toHaveBeenCalledWith({
+          email: "notfound@example.com",
+        });
+        expect(result).toBeNull();
+      });
+    });
+
+    describe("createWithEmailAndPassword", () => {
+      it("should create, save, and return the mapped user entity, excluding forbidden option overrides", async () => {
+        const mockSavedDoc = {
+          _id: "60f7c1234567890123456789",
+          email: "new@example.com",
+          password: "hashedpassword",
+          displayName: "New User",
+          anonymous: false,
+          verified: false,
+          ratings: { classic: 1000 },
+        };
+
+        let savedInstance: any = null;
+        const saveSpy = vi
+          .spyOn(UserModel.prototype, "save")
+          .mockImplementation(function (this: any) {
+            savedInstance = this;
+            return Promise.resolve(mockSavedDoc as any);
+          });
+
+        const result = await repository.createWithEmailAndPassword(
+          "new@example.com",
+          "hashedpassword",
+          {
+            displayName: "New User",
+            email: "should_be_ignored@example.com",
+            ratings: { classic: 2000 },
+            anonymous: true,
+            verified: true,
+          },
+        );
+
+        expect(saveSpy).toHaveBeenCalled();
+        expect(savedInstance).toBeDefined();
+        // Check that options sanitization worked:
+        expect(savedInstance.email).toBe("new@example.com"); // constructor override parameter
+        expect(savedInstance.displayName).toBe("New User"); // safe option
+        expect(savedInstance.anonymous).toBe(false); // set to false directly
+        expect(savedInstance.verified).toBe(false); // set to false directly
+
+        expect(result).toEqual({
+          id: "60f7c1234567890123456789",
+          email: "new@example.com",
+          password: "hashedpassword",
+          displayName: "New User",
+          anonymous: false,
+          verified: false,
+          ratings: { classic: 1000 },
+        });
+      });
+    });
+
+    describe("createAnonymous", () => {
+      it("should create, save, and return mapped anonymous user entity, excluding forbidden options", async () => {
+        const mockSavedDoc = {
+          _id: "60f7c123456789012345678a",
+          anonymous: true,
+          verified: false,
+          ratings: { classic: 1000 },
+        };
+
+        let savedInstance: any = null;
+        const saveSpy = vi
+          .spyOn(UserModel.prototype, "save")
+          .mockImplementation(function (this: any) {
+            savedInstance = this;
+            return Promise.resolve(mockSavedDoc as any);
+          });
+
+        const result = await repository.createAnonymous({
+          displayName: "Guest User",
+          anonymous: false, // forbidden override
+          verified: true, // forbidden override
+        });
+
+        expect(saveSpy).toHaveBeenCalled();
+        expect(savedInstance).toBeDefined();
+        expect(savedInstance.displayName).toBe("Guest User");
+        expect(savedInstance.anonymous).toBe(true);
+        expect(savedInstance.verified).toBe(false);
+
+        expect(result).toEqual({
+          id: "60f7c123456789012345678a",
+          email: undefined,
+          password: undefined,
+          displayName: undefined,
+          anonymous: true,
+          verified: false,
+          ratings: { classic: 1000 },
+        });
+      });
+    });
+
+    describe("updatePassword", () => {
+      it("should return true when update is acknowledged and matched", async () => {
+        const updateOneSpy = vi.spyOn(UserModel, "updateOne").mockReturnValue({
+          exec: vi.fn().mockResolvedValue({
+            acknowledged: true,
+            matchedCount: 1,
+          }),
+        } as any);
+
+        const result = await repository.updatePassword(
+          "test@example.com",
+          "newhash",
+        );
+
+        expect(updateOneSpy).toHaveBeenCalledWith(
+          { email: "test@example.com" },
+          { password: "newhash" },
+        );
+        expect(result).toBe(true);
+      });
+
+      it("should return false when update is not matched", async () => {
+        const updateOneSpy = vi.spyOn(UserModel, "updateOne").mockReturnValue({
+          exec: vi.fn().mockResolvedValue({
+            acknowledged: true,
+            matchedCount: 0,
+          }),
+        } as any);
+
+        const result = await repository.updatePassword(
+          "missing@example.com",
+          "newhash",
+        );
+
+        expect(updateOneSpy).toHaveBeenCalledWith(
+          { email: "missing@example.com" },
+          { password: "newhash" },
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("verifyEmail", () => {
+      it("should return true when email verification modifies a document", async () => {
+        const updateOneSpy = vi.spyOn(UserModel, "updateOne").mockReturnValue({
+          exec: vi.fn().mockResolvedValue({
+            modifiedCount: 1,
+          }),
+        } as any);
+
+        const result = await repository.verifyEmail("test@example.com");
+
+        expect(updateOneSpy).toHaveBeenCalledWith(
+          { email: "test@example.com" },
+          { verified: true },
+        );
+        expect(result).toBe(true);
+      });
+
+      it("should return false when no document is modified", async () => {
+        const updateOneSpy = vi.spyOn(UserModel, "updateOne").mockReturnValue({
+          exec: vi.fn().mockResolvedValue({
+            modifiedCount: 0,
+          }),
+        } as any);
+
+        const result = await repository.verifyEmail(
+          "already-verified@example.com",
+        );
+
+        expect(updateOneSpy).toHaveBeenCalledWith(
+          { email: "already-verified@example.com" },
+          { verified: true },
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("getRating", () => {
+      it("should return classic rating from database if it exists", async () => {
+        const mockUser = {
+          _id: "60f7c1234567890123456789",
+          ratings: { classic: 1540 },
+        };
+
+        const findByIdSpy = vi.spyOn(UserModel, "findById").mockReturnValue({
+          exec: vi.fn().mockResolvedValue(mockUser),
+        } as any);
+
+        const rating = await repository.getRating(
+          "60f7c1234567890123456789",
+          GameMode.CLASSIC,
+        );
+
+        expect(findByIdSpy).toHaveBeenCalledWith("60f7c1234567890123456789");
+        expect(rating).toBe(1540);
+      });
+
+      it("should return default rating 1000 if game mode rating is not set", async () => {
+        const mockUser = {
+          _id: "60f7c1234567890123456789",
+          ratings: {},
+        };
+
+        const findByIdSpy = vi.spyOn(UserModel, "findById").mockReturnValue({
+          exec: vi.fn().mockResolvedValue(mockUser),
+        } as any);
+
+        const rating = await repository.getRating(
+          "60f7c1234567890123456789",
+          GameMode.CLASSIC,
+        );
+
+        expect(findByIdSpy).toHaveBeenCalledWith("60f7c1234567890123456789");
+        expect(rating).toBe(1000);
+      });
+
+      it("should return default rating 1000 if user is not found", async () => {
+        const findByIdSpy = vi.spyOn(UserModel, "findById").mockReturnValue({
+          exec: vi.fn().mockResolvedValue(null),
+        } as any);
+
+        const rating = await repository.getRating(
+          "missing-id",
+          GameMode.CLASSIC,
+        );
+
+        expect(findByIdSpy).toHaveBeenCalledWith("missing-id");
+        expect(rating).toBe(1000);
+      });
+    });
+
+    describe("updateRatings", () => {
+      it("should call bulkWrite with the formatted updates", async () => {
+        const bulkWriteSpy = vi
+          .spyOn(UserModel, "bulkWrite")
+          .mockResolvedValue({} as any);
+
+        const updates = [
+          { userId: "user1", mode: GameMode.CLASSIC, newRating: 1050 },
+          { userId: "user2", mode: GameMode.DEMOLITION, newRating: 980 },
+        ];
+
+        await repository.updateRatings(updates);
+
+        expect(bulkWriteSpy).toHaveBeenCalledWith([
+          {
+            updateOne: {
+              filter: { _id: "user1" },
+              update: { $set: { "ratings.classic": 1050 } },
+            },
+          },
+          {
+            updateOne: {
+              filter: { _id: "user2" },
+              update: { $set: { "ratings.demolition": 980 } },
+            },
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/packages/engine/src/domain/grid/grid-generator.ts
+++ b/packages/engine/src/domain/grid/grid-generator.ts
@@ -128,14 +128,14 @@ export function isGrid(input: GridInput): input is IGrid {
     return false;
   }
 
-  const candidate = input as Record<string, unknown>;
+  const candidate = input as Partial<IGrid>;
 
   return (
-    typeof candidate["width"] === "number" &&
-    typeof candidate["height"] === "number" &&
-    typeof candidate["get"] === "function" &&
-    typeof candidate["forEach"] === "function" &&
-    typeof candidate["forEachTerrain"] === "function"
+    typeof candidate.width === "number" &&
+    typeof candidate.height === "number" &&
+    typeof candidate.get === "function" &&
+    typeof candidate.forEach === "function" &&
+    typeof candidate.forEachTerrain === "function"
   );
 }
 

--- a/packages/engine/tests/domain/game/turf-war-game.test.ts
+++ b/packages/engine/tests/domain/game/turf-war-game.test.ts
@@ -31,6 +31,22 @@ function createMoveAction(playerId = "p1"): MoveAction {
   };
 }
 
+function getCell(grid: Grid, x: number, y: number): Cell {
+  const cell = grid.get({ x, y });
+  if (!cell) throw new Error(`Cell at ${x},${y} not found`);
+  return cell;
+}
+
+function mustFind<T>(
+  arr: T[],
+  predicate: (item: T) => boolean,
+  label: string,
+): T {
+  const result = arr.find(predicate);
+  if (!result) throw new Error(`mustFind: ${label} not found`);
+  return result;
+}
+
 describe("TurfWarGame", () => {
   it("finishes game when one alive team remains", () => {
     const grid = createGridForTurfWar();
@@ -58,9 +74,9 @@ describe("TurfWarGame", () => {
     game.players.set(p1.playerId, p1);
     game.players.set(p2.playerId, p2);
 
-    const c0 = grid.get({ x: 0, y: 0 })!;
-    const c1 = grid.get({ x: 1, y: 0 })!;
-    const c2 = grid.get({ x: 2, y: 0 })!;
+    const c0 = getCell(grid, 0, 0);
+    const c1 = getCell(grid, 1, 0);
+    const c2 = getCell(grid, 2, 0);
 
     c0.owner = p1;
     c1.owner = p2;
@@ -100,16 +116,24 @@ describe("TurfWarGame", () => {
       game.players.set(p1.playerId, p1);
       game.players.set(p2.playerId, p2);
 
-      grid.get({ x: 0, y: 0 })!.owner = p1;
-      grid.get({ x: 1, y: 0 })!.owner = p1;
-      grid.get({ x: 3, y: 0 })!.owner = p2;
+      getCell(grid, 0, 0).owner = p1;
+      getCell(grid, 1, 0).owner = p1;
+      getCell(grid, 3, 0).owner = p2;
 
       game.startGame();
 
       const scoreboard = game.getScoreboard();
       // 3 capturable tiles (excludes MOUNTAIN at x:2), t1 owns 2 → 67%, t2 owns 1 → 33%
-      const t1Entry = scoreboard.teams.find((t) => t.teamId === "t1")!;
-      const t2Entry = scoreboard.teams.find((t) => t.teamId === "t2")!;
+      const t1Entry = mustFind(
+        scoreboard.teams,
+        (t) => t.teamId === "t1",
+        "team t1",
+      );
+      const t2Entry = mustFind(
+        scoreboard.teams,
+        (t) => t.teamId === "t2",
+        "team t2",
+      );
 
       expect(t1Entry.playerIds).toEqual(["p1"]);
       expect(t1Entry.landPercent).toBe(67);
@@ -128,9 +152,9 @@ describe("TurfWarGame", () => {
     game.players.set(p1.playerId, p1);
     game.players.set(p2.playerId, p2);
 
-    const c0 = grid.get({ x: 0, y: 0 })!;
-    const c1 = grid.get({ x: 1, y: 0 })!;
-    const c2 = grid.get({ x: 2, y: 0 })!;
+    const c0 = getCell(grid, 0, 0);
+    const c1 = getCell(grid, 1, 0);
+    const c2 = getCell(grid, 2, 0);
 
     c0.owner = p1;
     c0.troopCount = 10;


### PR DESCRIPTION
Closes #94 .

This pull request adds comprehensive unit tests for the `MongoUserRepository` and improves the clarity and robustness of test utilities in the Turf War game tests. It also refines type checks in the grid generator for better type safety and code readability.

**New MongoUserRepository Tests:**

* Added a new test suite `MongoUserRepository and UserModel tests` in `MongoUserRepository.test.ts` to validate schema defaults, input sanitization, and all repository methods, including `findByEmail`, `createWithEmailAndPassword`, `createAnonymous`, `updatePassword`, `verifyEmail`, `getRating`, and `updateRatings`. These tests use mocking to ensure correct database interactions and business logic.

**Test Utility Improvements in Turf War Game:**

* Introduced helper functions `getCell` (for safe cell retrieval) and `mustFind` (for array lookups with error messages) in `turf-war-game.test.ts` to make tests more robust and readable.
* Refactored existing tests to use `getCell` and `mustFind` for cell access and scoreboard lookups, improving error reporting and reducing code duplication. [[1]](diffhunk://#diff-06a7c9fa874eebcb2e2c26ef9bf33a8c3196fbcec9b6055b97795c79d87004ccL61-R79) [[2]](diffhunk://#diff-06a7c9fa874eebcb2e2c26ef9bf33a8c3196fbcec9b6055b97795c79d87004ccL103-R136) [[3]](diffhunk://#diff-06a7c9fa874eebcb2e2c26ef9bf33a8c3196fbcec9b6055b97795c79d87004ccL131-R157)

**Type Safety and Code Readability:**

* Updated the `isGrid` type guard in `grid-generator.ts` to use `Partial<IGrid>` and direct property access, enhancing type safety and code clarity.