### PR TITLE
feat(client): improve checkout interface logic

### DIFF
--- a/apps/client/src/components/ui/dialog.tsx
+++ b/apps/client/src/components/ui/dialog.tsx
@@ -37,7 +37,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className,
       )}
       {...props}

--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -106,6 +106,9 @@ export function GamePage({ connection, source }: GamePageProps) {
   const [splitMoveSelection, setSplitMoveSelection] =
     useState<ICoordinate | null>(null);
   const [isViewingAsSpectator, setIsViewingAsSpectator] = useState(false);
+  const [spectatorSource, setSpectatorSource] = useState<
+    "eliminated" | "game-end" | null
+  >(null);
   const renderGridWidth = renderGrid?.width ?? 0;
   const renderGridHeight = renderGrid?.height ?? 0;
 
@@ -171,8 +174,11 @@ export function GamePage({ connection, source }: GamePageProps) {
   };
 
   useEffect(() => {
-    setIsViewingAsSpectator(false);
-  }, []);
+    if (gameResult && spectatorSource === "eliminated") {
+      setIsViewingAsSpectator(false);
+      setSpectatorSource(null);
+    }
+  }, [gameResult, spectatorSource]);
 
   if (error) {
     return (
@@ -222,13 +228,13 @@ export function GamePage({ connection, source }: GamePageProps) {
     gameResult?.winnerTeamId &&
       currentPlayer?.teamId === gameResult.winnerTeamId,
   );
-  const activeModal = !isViewingAsSpectator
-    ? gameResult
-      ? "game-end"
-      : isPlayerEliminated
-        ? "eliminated"
-        : null
-    : null;
+  const activeModal = gameResult
+    ? isViewingAsSpectator && spectatorSource === "game-end"
+      ? null
+      : "game-end"
+    : !isViewingAsSpectator && isPlayerEliminated
+      ? "eliminated"
+      : null;
   const returnLabel =
     source.type === "official" ? "Return to lobby" : "Return to setup room";
 
@@ -301,6 +307,9 @@ export function GamePage({ connection, source }: GamePageProps) {
                 variant="outline"
                 onClick={() => {
                   setIsViewingAsSpectator(true);
+                  setSpectatorSource(
+                    activeModal === "eliminated" ? "eliminated" : "game-end",
+                  );
                   setSelection(null);
                   setSplitMoveSelection(null);
                 }}

--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -1,6 +1,6 @@
 import type { ICoordinate } from "@generals-plus/engine";
-import { ActionType } from "@generals-plus/engine";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { ActionType, PlayerStatus } from "@generals-plus/engine";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 
 import { ErrorPanel, LoadingPanel, StageCenter } from "#/components/layout";
@@ -105,6 +105,7 @@ export function GamePage({ connection, source }: GamePageProps) {
   const [selection, setSelection] = useState<ICoordinate | null>(null);
   const [splitMoveSelection, setSplitMoveSelection] =
     useState<ICoordinate | null>(null);
+  const [isViewingAsSpectator, setIsViewingAsSpectator] = useState(false);
   const renderGridWidth = renderGrid?.width ?? 0;
   const renderGridHeight = renderGrid?.height ?? 0;
 
@@ -169,6 +170,10 @@ export function GamePage({ connection, source }: GamePageProps) {
     }
   };
 
+  useEffect(() => {
+    setIsViewingAsSpectator(false);
+  }, []);
+
   if (error) {
     return (
       <StageCenter>
@@ -203,6 +208,10 @@ export function GamePage({ connection, source }: GamePageProps) {
   const currentPlayer = visiblePlayers.find(
     (player) => player.sessionId === room?.sessionId,
   );
+  const isPlayerEliminated =
+    currentPlayer?.status === PlayerStatus.ELIMINATED && !gameResult;
+  const isReadOnly =
+    isViewingAsSpectator || Boolean(gameResult) || isPlayerEliminated;
   const winnerId = gameResult?.winnerTeamId
     ? Array.from(gameState.publicPlayers.values()).find(
         (p) => p.teamId === gameResult.winnerTeamId,
@@ -213,18 +222,37 @@ export function GamePage({ connection, source }: GamePageProps) {
     gameResult?.winnerTeamId &&
       currentPlayer?.teamId === gameResult.winnerTeamId,
   );
+  const activeModal = !isViewingAsSpectator
+    ? gameResult
+      ? "game-end"
+      : isPlayerEliminated
+        ? "eliminated"
+        : null
+    : null;
+  const returnLabel =
+    source.type === "official" ? "Return to lobby" : "Return to setup room";
 
   return (
     <div className="fixed inset-0 z-20 bg-game-bg">
+      {isViewingAsSpectator ? (
+        <div className="pointer-events-none fixed inset-x-0 top-0 z-30 p-3">
+          <div className="pointer-events-auto">
+            <Button type="button" variant="outline" onClick={handleReturn}>
+              Return
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
       <GameApp
         grid={renderGrid}
-        selection={selection}
-        splitMoveSelection={splitMoveSelection}
+        selection={isReadOnly ? null : selection}
+        splitMoveSelection={isReadOnly ? null : splitMoveSelection}
         moveQueue={moveQueue}
-        onSelectCell={handleSelectCell}
-        onArmSplitMove={handleArmSplitMove}
-        onQueueMove={handleQueueMove}
-        onClearMoveQueue={clearMoveQueue}
+        onSelectCell={isReadOnly ? () => {} : handleSelectCell}
+        onArmSplitMove={isReadOnly ? () => {} : handleArmSplitMove}
+        onQueueMove={isReadOnly ? () => {} : handleQueueMove}
+        onClearMoveQueue={isReadOnly ? () => {} : clearMoveQueue}
         playerColors={playerColors}
       />
 
@@ -237,7 +265,7 @@ export function GamePage({ connection, source }: GamePageProps) {
         }}
       />
 
-      {gameResult ? (
+      {activeModal ? (
         <Dialog open={true}>
           <DialogContent
             className="max-w-sm"
@@ -248,18 +276,41 @@ export function GamePage({ connection, source }: GamePageProps) {
           >
             <DialogHeader>
               <DialogTitle className="text-2xl">
-                {didWin ? "You won" : winnerId ? "You lost" : "Game over"}
+                {activeModal === "eliminated"
+                  ? "You have been eliminated"
+                  : didWin
+                    ? "You won"
+                    : winnerId
+                      ? "You lost"
+                      : "Game over"}
               </DialogTitle>
             </DialogHeader>
             <div className="mt-3 space-y-1 text-sm text-game-text-dim">
-              {!didWin && winnerName ? <p>Winner: {winnerName}</p> : null}
-              {!gameResult.winnerTeamId ? <p>No winner was reported.</p> : null}
+              {activeModal === "eliminated" ? null : (
+                <>
+                  {!didWin && winnerName ? <p>Winner: {winnerName}</p> : null}
+                  {!gameResult?.winnerTeamId ? (
+                    <p>No winner was reported.</p>
+                  ) : null}
+                </>
+              )}
             </div>
-            <Button type="button" onClick={handleReturn} className="mt-5">
-              {source.type === "official"
-                ? "Return to lobby"
-                : "Return to setup room"}
-            </Button>
+            <div className="mt-5 flex flex-col gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setIsViewingAsSpectator(true);
+                  setSelection(null);
+                  setSplitMoveSelection(null);
+                }}
+              >
+                View as spectator
+              </Button>
+              <Button type="button" onClick={handleReturn}>
+                {returnLabel}
+              </Button>
+            </div>
           </DialogContent>
         </Dialog>
       ) : null}

--- a/apps/client/tests/features/game/pages/game-page.test.tsx
+++ b/apps/client/tests/features/game/pages/game-page.test.tsx
@@ -110,6 +110,40 @@ function createScoreboard() {
   return scoreboard;
 }
 
+function createGameState(
+  playerOverrides: Partial<Player> = {},
+  extraPublicPlayers: Array<{
+    id: string;
+    teamId: string;
+    displayName: string;
+    color: number;
+    status: PlayerStatus;
+  }> = [],
+) {
+  const player = createPlayer(playerOverrides);
+  return {
+    mode: GameMode.CLASSIC,
+    scoreboard: createScoreboard(),
+    players: new Map([["player-1", player]]),
+    publicPlayers: new Map([
+      [
+        "player-1",
+        {
+          id: "player-1",
+          teamId: player.teamId,
+          displayName: player.displayName,
+          color: player.color,
+          status: player.status,
+        },
+      ],
+      ...extraPublicPlayers.map((publicPlayer) => [
+        publicPlayer.id,
+        publicPlayer,
+      ]),
+    ]),
+  };
+}
+
 describe("GamePage keyboard move bounds", () => {
   beforeEach(() => {
     clearPersistedGameSessionMock.mockReset();
@@ -119,18 +153,11 @@ describe("GamePage keyboard move bounds", () => {
   });
 
   it("does not queue a move that would leave the map", () => {
-    const player = createPlayer();
-
     useGameRoomMock.mockReturnValue({
       room: { sessionId: "player-1" },
       renderGrid: createRenderGrid(1, 1),
       moveQueue: [],
-      gameState: {
-        mode: GameMode.CLASSIC,
-        scoreboard: createScoreboard(),
-        players: new Map([["player-1", player]]),
-        publicPlayers: new Map(),
-      },
+      gameState: createGameState(),
       gameResult: null,
       sendMove: sendMoveMock,
       clearMoveQueue: vi.fn(),
@@ -155,5 +182,93 @@ describe("GamePage keyboard move bounds", () => {
     fireEvent.click(screen.getByTestId("move-left"));
 
     expect(sendMoveMock).not.toHaveBeenCalled();
+  });
+
+  it("allows viewing a finished game as spectator before returning", () => {
+    const onReturn = vi.fn();
+
+    useGameRoomMock.mockReturnValue({
+      room: { sessionId: "player-1" },
+      renderGrid: createRenderGrid(2, 2),
+      moveQueue: [],
+      gameState: createGameState({}, [
+        {
+          id: "player-2",
+          teamId: "team-2",
+          displayName: "Rook",
+          color: 0xff6633,
+          status: PlayerStatus.ACTIVE,
+        },
+      ]),
+      gameResult: {
+        mode: GameMode.CLASSIC,
+        winnerTeamId: "team-2",
+      },
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      playerColors: new Map(),
+      playerNames: new Map([["player-2", "Rook"]]),
+      connectionStatus: "connected",
+      error: null,
+      isConnecting: false,
+    });
+
+    render(
+      <GamePage
+        connection={{
+          type: "recovery",
+          recoveryToken: "token-1",
+        }}
+        source={{ type: "official", onReturn }}
+      />,
+    );
+
+    expect(screen.getByText("You lost")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "View as spectator" }));
+
+    expect(screen.queryByText("You lost")).toBeNull();
+    expect(screen.getByRole("button", { name: "Return" })).toBeTruthy();
+    expect(onReturn).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Return" }));
+
+    expect(clearPersistedGameSessionMock).toHaveBeenCalled();
+    expect(onReturn).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers spectator view after the current player is eliminated", () => {
+    const onReturn = vi.fn();
+
+    useGameRoomMock.mockReturnValue({
+      room: { sessionId: "player-1" },
+      renderGrid: createRenderGrid(2, 2),
+      moveQueue: [],
+      gameState: createGameState({ status: PlayerStatus.ELIMINATED }),
+      gameResult: null,
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      playerColors: new Map(),
+      playerNames: new Map(),
+      connectionStatus: "connected",
+      error: null,
+      isConnecting: false,
+    });
+
+    render(
+      <GamePage
+        connection={{
+          type: "recovery",
+          recoveryToken: "token-2",
+        }}
+        source={{ type: "official", onReturn }}
+      />,
+    );
+
+    expect(screen.getByText("You have been eliminated")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "View as spectator" }));
+
+    expect(screen.queryByText("You have been eliminated")).toBeNull();
+    expect(screen.getByRole("button", { name: "Return" })).toBeTruthy();
+    expect(onReturn).not.toHaveBeenCalled();
   });
 });

--- a/apps/client/tests/features/game/pages/game-page.test.tsx
+++ b/apps/client/tests/features/game/pages/game-page.test.tsx
@@ -125,7 +125,16 @@ function createGameState(
     mode: GameMode.CLASSIC,
     scoreboard: createScoreboard(),
     players: new Map([["player-1", player]]),
-    publicPlayers: new Map([
+    publicPlayers: new Map<
+      string,
+      {
+        id: string;
+        teamId: string;
+        displayName: string;
+        color: number;
+        status: PlayerStatus;
+      }
+    >([
       [
         "player-1",
         {
@@ -136,10 +145,9 @@ function createGameState(
           status: player.status,
         },
       ],
-      ...extraPublicPlayers.map((publicPlayer) => [
-        publicPlayer.id,
-        publicPlayer,
-      ]),
+      ...extraPublicPlayers.map(
+        (publicPlayer) => [publicPlayer.id, publicPlayer] as const,
+      ),
     ]),
   };
 }


### PR DESCRIPTION
Closes #86.
Main changes:
1. Removed the frosted glass effect from the background of the pop-up window.
2. Added a pop-up window that appears when a player has been eliminated but the game is not over.
3. Added a button option to become a spectator and a "Return" button while spectating.