### PR TITLE
fix(client): fix room refresh page twice

### DIFF
--- a/apps/client/src/features/game/api/game-room-errors.ts
+++ b/apps/client/src/features/game/api/game-room-errors.ts
@@ -1,0 +1,66 @@
+export type GameRoomErrorCode =
+  | "MATCH_CONNECT_FAILED"
+  | "RECOVERY_FAILED"
+  | "RECOVERY_TIMEOUT"
+  | "RECOVERY_ROOM_NOT_FOUND"
+  | "RECOVERY_TOKEN_INVALID";
+
+export class GameRoomError extends Error {
+  code: GameRoomErrorCode;
+
+  constructor(code: GameRoomErrorCode, message: string, cause?: unknown) {
+    super(message);
+    this.name = "GameRoomError";
+    this.code = code;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}
+
+export function isTerminalRecoveryErrorCode(code: GameRoomErrorCode | null) {
+  return (
+    code === "RECOVERY_ROOM_NOT_FOUND" || code === "RECOVERY_TOKEN_INVALID"
+  );
+}
+
+export function normalizeRecoveryError(error: unknown): GameRoomError {
+  if (error instanceof GameRoomError) {
+    return error;
+  }
+
+  const message =
+    error instanceof Error && error.message.trim()
+      ? error.message
+      : "Failed to connect to match";
+  const normalized = message.toLowerCase();
+
+  if (normalized.includes("room not found")) {
+    return new GameRoomError("RECOVERY_ROOM_NOT_FOUND", message, error);
+  }
+
+  if (normalized.includes("reconnection token invalid or expired")) {
+    return new GameRoomError("RECOVERY_TOKEN_INVALID", message, error);
+  }
+
+  return new GameRoomError("RECOVERY_FAILED", message, error);
+}
+
+export function normalizeGameRoomError(
+  error: unknown,
+  connectionType: "reservation" | "recovery",
+) {
+  if (connectionType === "recovery") {
+    return normalizeRecoveryError(error);
+  }
+
+  if (error instanceof GameRoomError) {
+    return error;
+  }
+
+  const message =
+    error instanceof Error && error.message.trim()
+      ? error.message
+      : "Failed to connect to match";
+  return new GameRoomError("MATCH_CONNECT_FAILED", message, error);
+}

--- a/apps/client/src/features/game/api/use-game-room.ts
+++ b/apps/client/src/features/game/api/use-game-room.ts
@@ -17,6 +17,12 @@ import {
 } from "@generals-plus/shared-types";
 import { useCallback, useEffect, useState } from "react";
 
+import type { GameRoomErrorCode } from "#/features/game/api/game-room-errors";
+import {
+  GameRoomError,
+  isTerminalRecoveryErrorCode,
+  normalizeGameRoomError,
+} from "#/features/game/api/game-room-errors";
 import type { RenderGrid } from "#/features/game/renderer/render-grid";
 import { createRenderGrid } from "#/features/game/utils/grid-adapter";
 import type { MoveIntent } from "#/features/game/utils/move";
@@ -77,6 +83,8 @@ export interface PersistedGameSession {
 const ACTIVE_GAME_SESSION_KEY = "generals_plus_active_game_session";
 /** Upper bound for recovery attempts so stale tokens cannot trap the UI. */
 const RECOVERY_TIMEOUT_MS = 10_000;
+const RECOVERY_TIMEOUT_MESSAGE =
+  "Unable to restore the match. The room may have ended or expired.";
 
 /**
  * Read the persisted match recovery session, ignoring malformed or unavailable
@@ -244,11 +252,11 @@ function acquireGameRoom(connection: GameRoomConnection) {
 function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
-  timeoutMessage: string,
+  timeoutErrorFactory: () => Error,
 ) {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
-      reject(new Error(timeoutMessage));
+      reject(timeoutErrorFactory());
     }, timeoutMs);
 
     promise
@@ -332,6 +340,7 @@ export function useGameRoom(
     new Map(),
   );
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<GameRoomErrorCode | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectionStatus, setConnectionStatus] = useState("connecting");
 
@@ -344,6 +353,7 @@ export function useGameRoom(
     const connect = async () => {
       setIsConnecting(true);
       setError(null);
+      setErrorCode(null);
       setGameResult(null);
       setConnectionStatus("connecting");
       try {
@@ -351,7 +361,8 @@ export function useGameRoom(
           ? withTimeout(
               acquireGameRoom(connection),
               RECOVERY_TIMEOUT_MS,
-              "Unable to restore the match. The room may have ended or expired.",
+              () =>
+                new GameRoomError("RECOVERY_TIMEOUT", RECOVERY_TIMEOUT_MESSAGE),
             )
           : acquireGameRoom(connection));
         if (!isCurrent) {
@@ -427,13 +438,16 @@ export function useGameRoom(
         );
       } catch (error) {
         if (!isCurrent) return;
-        if (connection.type === "recovery") {
+        const normalizedError = normalizeGameRoomError(error, connection.type);
+        if (
+          connection.type === "recovery" &&
+          isTerminalRecoveryErrorCode(normalizedError.code)
+        ) {
           clearPersistedGameSession();
         }
         setIsConnecting(false);
-        setError(
-          error instanceof Error ? error.message : "Failed to connect to match",
-        );
+        setErrorCode(normalizedError.code);
+        setError(normalizedError.message);
       }
     };
 
@@ -480,6 +494,7 @@ export function useGameRoom(
     playerColors,
     playerNames,
     connectionStatus,
+    errorCode,
     error,
     isConnecting,
   };

--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -43,6 +43,8 @@ interface GamePageProps {
   connection: GameRoomConnection;
   /** Return behavior and metadata for the flow that launched the match. */
   source: GamePageSource;
+  /** Optional hook for routes that should abandon a stale recovery path. */
+  onRecoveryFailed?: () => void;
 }
 
 /**
@@ -54,7 +56,11 @@ interface GamePageProps {
  * official matches and `/match/:roomId` custom matches can reuse the same game
  * surface after their respective seat-reservation handoff.
  */
-export function GamePage({ connection, source }: GamePageProps) {
+export function GamePage({
+  connection,
+  source,
+  onRecoveryFailed,
+}: GamePageProps) {
   const navigate = useNavigate();
   /**
    * Keep the full connection payload stable across parent re-renders.
@@ -77,6 +83,7 @@ export function GamePage({ connection, source }: GamePageProps) {
   }
   const stableConnection = stableConnectionRef.current.value;
   const customRoomKey = source.type === "custom" ? source.customRoomKey : null;
+  const hasHandledRecoveryFailureRef = useRef(false);
 
   /**
    * Memoized route context persisted alongside the recovery token.
@@ -179,6 +186,38 @@ export function GamePage({ connection, source }: GamePageProps) {
       setSpectatorSource(null);
     }
   }, [gameResult, spectatorSource]);
+
+  useEffect(() => {
+    hasHandledRecoveryFailureRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    if (
+      !error ||
+      connection.type !== "recovery" ||
+      source.type !== "custom" ||
+      !onRecoveryFailed ||
+      hasHandledRecoveryFailureRef.current
+    ) {
+      return;
+    }
+
+    hasHandledRecoveryFailureRef.current = true;
+    onRecoveryFailed();
+  }, [connection.type, error, onRecoveryFailed, source.type]);
+
+  if (
+    error &&
+    connection.type === "recovery" &&
+    source.type === "custom" &&
+    onRecoveryFailed
+  ) {
+    return (
+      <StageCenter>
+        <LoadingPanel message="Rejoining custom room" />
+      </StageCenter>
+    );
+  }
 
   if (error) {
     return (

--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -52,8 +52,7 @@ interface GamePageProps {
  * Only terminal recovery failures should abandon the match URL and return to
  * setup. Transient network failures still need the visible error panel so the
  * user can retry/diagnose without discarding a potentially valid live match.
- */
-/**
+ *
  * Match view rendered after queue/setup hands the client a seat reservation.
  *
  * The page delegates socket ownership and state adaptation to `useGameRoom`,

--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -11,6 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "#/components/ui/dialog";
+import { isTerminalRecoveryErrorCode } from "#/features/game/api/game-room-errors";
 import type { GameRoomConnection } from "#/features/game/api/use-game-room";
 import {
   clearPersistedGameSession,
@@ -48,6 +49,11 @@ interface GamePageProps {
 }
 
 /**
+ * Only terminal recovery failures should abandon the match URL and return to
+ * setup. Transient network failures still need the visible error panel so the
+ * user can retry/diagnose without discarding a potentially valid live match.
+ */
+/**
  * Match view rendered after queue/setup hands the client a seat reservation.
  *
  * The page delegates socket ownership and state adaptation to `useGameRoom`,
@@ -84,6 +90,8 @@ export function GamePage({
   const stableConnection = stableConnectionRef.current.value;
   const customRoomKey = source.type === "custom" ? source.customRoomKey : null;
   const hasHandledRecoveryFailureRef = useRef(false);
+  const recoveryFailedHandlerRef = useRef(onRecoveryFailed);
+  recoveryFailedHandlerRef.current = onRecoveryFailed;
 
   /**
    * Memoized route context persisted alongside the recovery token.
@@ -106,8 +114,15 @@ export function GamePage({
     playerColors,
     playerNames,
     error,
+    errorCode,
     isConnecting,
   } = useGameRoom(stableConnection, persistedSource);
+  const shouldFallbackToSetup =
+    Boolean(errorCode) &&
+    connection.type === "recovery" &&
+    source.type === "custom" &&
+    Boolean(onRecoveryFailed) &&
+    isTerminalRecoveryErrorCode(errorCode);
 
   const [selection, setSelection] = useState<ICoordinate | null>(null);
   const [splitMoveSelection, setSplitMoveSelection] =
@@ -188,30 +203,21 @@ export function GamePage({
   }, [gameResult, spectatorSource]);
 
   useEffect(() => {
-    hasHandledRecoveryFailureRef.current = false;
-  }, []);
+    if (!shouldFallbackToSetup) {
+      hasHandledRecoveryFailureRef.current = false;
+      return;
+    }
 
-  useEffect(() => {
-    if (
-      !error ||
-      connection.type !== "recovery" ||
-      source.type !== "custom" ||
-      !onRecoveryFailed ||
-      hasHandledRecoveryFailureRef.current
-    ) {
+    const recoveryFailedHandler = recoveryFailedHandlerRef.current;
+    if (hasHandledRecoveryFailureRef.current || !recoveryFailedHandler) {
       return;
     }
 
     hasHandledRecoveryFailureRef.current = true;
-    onRecoveryFailed();
-  }, [connection.type, error, onRecoveryFailed, source.type]);
+    recoveryFailedHandler();
+  }, [shouldFallbackToSetup]);
 
-  if (
-    error &&
-    connection.type === "recovery" &&
-    source.type === "custom" &&
-    onRecoveryFailed
-  ) {
+  if (shouldFallbackToSetup) {
     return (
       <StageCenter>
         <LoadingPanel message="Rejoining custom room" />

--- a/apps/client/src/routes/match.$roomId.tsx
+++ b/apps/client/src/routes/match.$roomId.tsx
@@ -51,6 +51,9 @@ export default function MatchRoute() {
             type: "recovery",
             recoveryToken: customRecoveryToken,
           }}
+          onRecoveryFailed={() => {
+            setPersistedGameSession(null);
+          }}
           source={{
             type: "custom",
             customRoomKey: roomId,

--- a/apps/client/tests/features/game/pages/game-page.test.tsx
+++ b/apps/client/tests/features/game/pages/game-page.test.tsx
@@ -11,6 +11,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { isTerminalRecoveryErrorCode } from "#/features/game/api/game-room-errors";
 import { GamePage } from "#/features/game/pages/game-page";
 import type { RenderGridCell } from "#/features/game/renderer/render-grid";
 import { RenderGrid } from "#/features/game/renderer/render-grid";
@@ -172,6 +173,7 @@ describe("GamePage keyboard move bounds", () => {
       playerColors: new Map(),
       playerNames: new Map(),
       connectionStatus: "connected",
+      errorCode: null,
       error: null,
       isConnecting: false,
     });
@@ -217,6 +219,7 @@ describe("GamePage keyboard move bounds", () => {
       playerColors: new Map(),
       playerNames: new Map([["player-2", "Rook"]]),
       connectionStatus: "connected",
+      errorCode: null,
       error: null,
       isConnecting: false,
     });
@@ -258,6 +261,7 @@ describe("GamePage keyboard move bounds", () => {
       playerColors: new Map(),
       playerNames: new Map(),
       connectionStatus: "connected",
+      errorCode: null,
       error: null,
       isConnecting: false,
     });
@@ -278,5 +282,200 @@ describe("GamePage keyboard move bounds", () => {
     expect(screen.queryByText("You have been eliminated")).toBeNull();
     expect(screen.getByRole("button", { name: "Return" })).toBeTruthy();
     expect(onReturn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to setup only for terminal custom recovery errors", () => {
+    const onRecoveryFailed = vi.fn();
+
+    useGameRoomMock.mockReturnValue({
+      room: null,
+      renderGrid: null,
+      moveQueue: [],
+      gameState: null,
+      gameResult: null,
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      playerColors: new Map(),
+      playerNames: new Map(),
+      connectionStatus: "error",
+      errorCode: "RECOVERY_TOKEN_INVALID",
+      error: "reconnection token invalid or expired",
+      isConnecting: false,
+    });
+
+    render(
+      <GamePage
+        connection={{
+          type: "recovery",
+          recoveryToken: "token-stale",
+        }}
+        source={{
+          type: "custom",
+          customRoomKey: "custom-room",
+          onReturn: vi.fn(),
+        }}
+        onRecoveryFailed={onRecoveryFailed}
+      />,
+    );
+
+    expect(screen.getByText("Rejoining custom room")).toBeTruthy();
+    expect(onRecoveryFailed).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps custom recovery connection failures visible when they may be transient", () => {
+    const onRecoveryFailed = vi.fn();
+
+    useGameRoomMock.mockReturnValue({
+      room: null,
+      renderGrid: null,
+      moveQueue: [],
+      gameState: null,
+      gameResult: null,
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      playerColors: new Map(),
+      playerNames: new Map(),
+      connectionStatus: "error",
+      errorCode: "RECOVERY_TIMEOUT",
+      error: "Unable to restore the match. The room may have ended or expired.",
+      isConnecting: false,
+    });
+
+    render(
+      <GamePage
+        connection={{
+          type: "recovery",
+          recoveryToken: "token-timeout",
+        }}
+        source={{
+          type: "custom",
+          customRoomKey: "custom-room",
+          onReturn: vi.fn(),
+        }}
+        onRecoveryFailed={onRecoveryFailed}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Connection failed" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Unable to restore the match\. The room may have ended or expired\./,
+      ),
+    ).toBeTruthy();
+    expect(onRecoveryFailed).not.toHaveBeenCalled();
+  });
+
+  it("re-arms recovery fallback after the error clears and returns", () => {
+    const firstHandler = vi.fn();
+    const secondHandler = vi.fn();
+
+    useGameRoomMock.mockReturnValue({
+      room: null,
+      renderGrid: null,
+      moveQueue: [],
+      gameState: null,
+      gameResult: null,
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      playerColors: new Map(),
+      playerNames: new Map(),
+      connectionStatus: "error",
+      errorCode: "RECOVERY_TOKEN_INVALID",
+      error: "reconnection token invalid or expired",
+      isConnecting: false,
+    });
+
+    const { rerender } = render(
+      <GamePage
+        connection={{
+          type: "recovery",
+          recoveryToken: "token-stale",
+        }}
+        source={{
+          type: "custom",
+          customRoomKey: "custom-room",
+          onReturn: vi.fn(),
+        }}
+        onRecoveryFailed={firstHandler}
+      />,
+    );
+
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+
+    useGameRoomMock.mockReturnValue({
+      room: null,
+      renderGrid: null,
+      moveQueue: [],
+      gameState: null,
+      gameResult: null,
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      playerColors: new Map(),
+      playerNames: new Map(),
+      connectionStatus: "connecting",
+      errorCode: null,
+      error: null,
+      isConnecting: true,
+    });
+
+    rerender(
+      <GamePage
+        connection={{
+          type: "recovery",
+          recoveryToken: "token-stale",
+        }}
+        source={{
+          type: "custom",
+          customRoomKey: "custom-room",
+          onReturn: vi.fn(),
+        }}
+        onRecoveryFailed={secondHandler}
+      />,
+    );
+
+    useGameRoomMock.mockReturnValue({
+      room: null,
+      renderGrid: null,
+      moveQueue: [],
+      gameState: null,
+      gameResult: null,
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      playerColors: new Map(),
+      playerNames: new Map(),
+      connectionStatus: "error",
+      errorCode: "RECOVERY_TOKEN_INVALID",
+      error: "reconnection token invalid or expired",
+      isConnecting: false,
+    });
+
+    rerender(
+      <GamePage
+        connection={{
+          type: "recovery",
+          recoveryToken: "token-stale",
+        }}
+        source={{
+          type: "custom",
+          customRoomKey: "custom-room",
+          onReturn: vi.fn(),
+        }}
+        onRecoveryFailed={secondHandler}
+      />,
+    );
+
+    expect(firstHandler).toHaveBeenCalledTimes(1);
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isTerminalRecoveryErrorCode", () => {
+  it("matches only explicit stale-room recovery failures", () => {
+    expect(isTerminalRecoveryErrorCode("RECOVERY_ROOM_NOT_FOUND")).toBe(true);
+    expect(isTerminalRecoveryErrorCode("RECOVERY_TOKEN_INVALID")).toBe(true);
+    expect(isTerminalRecoveryErrorCode("RECOVERY_TIMEOUT")).toBe(false);
+    expect(isTerminalRecoveryErrorCode("RECOVERY_FAILED")).toBe(false);
   });
 });

--- a/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
+++ b/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
@@ -845,13 +845,11 @@ describe("client room flows", () => {
   it("stops waiting when persisted match recovery never resolves", async () => {
     vi.useFakeTimers();
     networkMocks.restoreSession.mockReturnValue(new Promise(() => {}));
-    localStorage.setItem(
-      "generals_plus_active_game_session",
-      JSON.stringify({
-        recoveryToken: "hung-token",
-        source: { type: "official" },
-      }),
-    );
+    const persistedSession = JSON.stringify({
+      recoveryToken: "hung-token",
+      source: { type: "official" },
+    });
+    localStorage.setItem("generals_plus_active_game_session", persistedSession);
 
     renderRoute("/", auth());
 
@@ -866,9 +864,38 @@ describe("client room flows", () => {
       screen.getByRole("heading", { name: "Connection failed" }),
     ).toBeTruthy();
     expect(screen.getByText(/Unable to restore the match/)).toBeTruthy();
+    expect(localStorage.getItem("generals_plus_active_game_session")).toBe(
+      persistedSession,
+    );
+  });
+
+  it("keeps custom recovery timeouts on the error panel instead of silently rejoining setup", async () => {
+    vi.useFakeTimers();
+    networkMocks.restoreSession.mockReturnValue(new Promise(() => {}));
+    const persistedSession = JSON.stringify({
+      recoveryToken: "hung-custom-token",
+      source: { type: "custom", customRoomKey: "setup-timeout" },
+    });
+    localStorage.setItem("generals_plus_active_game_session", persistedSession);
+
+    renderRoute("/match/setup-timeout", auth());
+
+    expect(screen.getByText("Connecting to match")).toBeTruthy();
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
     expect(
-      localStorage.getItem("generals_plus_active_game_session"),
-    ).toBeNull();
+      screen.getByRole("heading", { name: "Connection failed" }),
+    ).toBeTruthy();
+    expect(screen.getByText(/Unable to restore the match/)).toBeTruthy();
+    expect(networkMocks.resolveCustomRoom).not.toHaveBeenCalled();
+    expect(networkMocks.joinById).not.toHaveBeenCalled();
+    expect(localStorage.getItem("generals_plus_active_game_session")).toBe(
+      persistedSession,
+    );
   });
 
   it("resolves a fresh setup room after returning from a finished custom match", async () => {

--- a/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
+++ b/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
@@ -809,8 +809,20 @@ describe("client room flows", () => {
     expect(networkMocks.joinById).not.toHaveBeenCalled();
   });
 
-  it("shows a lobby escape when a persisted match recovery token is stale", async () => {
+  it("falls back to the setup room when a persisted custom recovery token is stale", async () => {
     networkMocks.restoreSession.mockRejectedValue(new Error("room not found"));
+    const setupRoom = createRoom({
+      roomId: "setup-stale",
+      state: createSetupState([
+        {
+          id: "player-1",
+          displayName: "Nova",
+          color: PLAYER_COLOR_PALETTE[0],
+          isHost: true,
+        },
+      ]),
+    });
+    networkMocks.joinById.mockResolvedValue(setupRoom);
     localStorage.setItem(
       "generals_plus_active_game_session",
       JSON.stringify({
@@ -821,17 +833,13 @@ describe("client room flows", () => {
 
     renderRoute("/match/setup-stale", auth());
 
-    expect(
-      await screen.findByRole("heading", { name: "Connection failed" }),
-    ).toBeTruthy();
-    expect(screen.getByText(/room not found/)).toBeTruthy();
+    expect(await screen.findByText("You are host")).toBeTruthy();
     expect(
       localStorage.getItem("generals_plus_active_game_session"),
     ).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Return to lobby" }));
-
-    expect(await screen.findByRole("button", { name: "Start" })).toBeTruthy();
+    expect(networkMocks.restoreSession).toHaveBeenCalledWith("stale-token");
+    expect(networkMocks.resolveCustomRoom).toHaveBeenCalledWith("setup-stale");
+    expect(networkMocks.joinById).toHaveBeenCalledWith("setup-stale");
   });
 
   it("stops waiting when persisted match recovery never resolves", async () => {


### PR DESCRIPTION
Closes #100.

This pull request introduces a robust error handling system for game room recovery and connection flows, distinguishing between terminal and transient errors. It adds a new `GameRoomError` class and related utilities, updates the `useGameRoom` hook and `GamePage` component to handle error codes, and ensures that terminal recovery failures for custom matches automatically fall back to the setup screen. Comprehensive tests are included to verify these behaviors.

**Error handling and recovery improvements:**

* Introduced `GameRoomError` class and `GameRoomErrorCode` type in `game-room-errors.ts`, with utilities to normalize errors and identify terminal recovery failures (`RECOVERY_ROOM_NOT_FOUND`, `RECOVERY_TOKEN_INVALID`).
* Updated the `useGameRoom` hook to use the new error handling system, track error codes, and clear persisted sessions on terminal recovery errors. [[1]](diffhunk://#diff-d9cebac3fcbbb14b38b03fa15a80640ff13b09984c90ffb2293891b01d8aedb7R20-R25) [[2]](diffhunk://#diff-d9cebac3fcbbb14b38b03fa15a80640ff13b09984c90ffb2293891b01d8aedb7R86-R87) [[3]](diffhunk://#diff-d9cebac3fcbbb14b38b03fa15a80640ff13b09984c90ffb2293891b01d8aedb7L247-R259) [[4]](diffhunk://#diff-d9cebac3fcbbb14b38b03fa15a80640ff13b09984c90ffb2293891b01d8aedb7R343) [[5]](diffhunk://#diff-d9cebac3fcbbb14b38b03fa15a80640ff13b09984c90ffb2293891b01d8aedb7R356-R365) [[6]](diffhunk://#diff-d9cebac3fcbbb14b38b03fa15a80640ff13b09984c90ffb2293891b01d8aedb7L430-R450) [[7]](diffhunk://#diff-d9cebac3fcbbb14b38b03fa15a80640ff13b09984c90ffb2293891b01d8aedb7R497)

**UI and routing changes:**

* Enhanced `GamePage` to accept an `onRecoveryFailed` callback and automatically fallback to the setup screen for terminal custom recovery errors, showing a loading panel during the transition. [[1]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29R14) [[2]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29R47-R55) [[3]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29L57-R69) [[4]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29R92-R94) [[5]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29R117-R125) [[6]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29R205-R227) [[7]](diffhunk://#diff-89fcb06b415ba676f3432df7bf865a61af070b70a50dc258b53c12b021211433R54-R56)

**Testing and verification:**

* Added and updated tests to verify fallback behavior for terminal recovery errors, distinguish between transient and terminal failures, and ensure correct re-arming of recovery fallback logic. [[1]](diffhunk://#diff-8773e3b6e5e62c9155a4a714c796f307944a529b79cdaeb8545085310495a207R14) [[2]](diffhunk://#diff-8773e3b6e5e62c9155a4a714c796f307944a529b79cdaeb8545085310495a207R176) [[3]](diffhunk://#diff-8773e3b6e5e62c9155a4a714c796f307944a529b79cdaeb8545085310495a207R222) [[4]](diffhunk://#diff-8773e3b6e5e62c9155a4a714c796f307944a529b79cdaeb8545085310495a207R264) [[5]](diffhunk://#diff-8773e3b6e5e62c9155a4a714c796f307944a529b79cdaeb8545085310495a207R286-R480)
* Adjusted flow tests to expect fallback to the setup room when a custom recovery token is stale, ensuring the UI transitions as intended. [[1]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fL812-R825) [[2]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fL824-R852)