### PR TITLE
feat(client, server): custom game url

### DIFF
--- a/apps/client/src/features/lobby/pages/lobby-page.tsx
+++ b/apps/client/src/features/lobby/pages/lobby-page.tsx
@@ -1,4 +1,9 @@
 import type { GameMode } from "@generals-plus/engine";
+import {
+  CUSTOM_ROOM_KEY_MAX_LENGTH,
+  CUSTOM_ROOM_KEY_MIN_LENGTH,
+  isValidCustomRoomKeyLength,
+} from "@generals-plus/shared-types";
 import { LogOut, Play, Plus } from "lucide-react";
 import { useState } from "react";
 import { useNavigate } from "react-router";
@@ -11,13 +16,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from "#/components/ui/dialog";
+import { Input } from "#/components/ui/input";
 import { GAME_MODE_OPTIONS } from "#/config/ui-constants";
 import { useAuth, useUser } from "#/features/auth/hooks";
 import { clearPersistedGameSession } from "#/features/game/api/use-game-room";
 import { useMatchConnectionStore } from "#/features/match/store/match-connection-store";
 import { networkProvider } from "#/infra/network/provider";
+import { HttpRequestError } from "#/infra/network/provider/colyseus";
 
 type ModeOption = (typeof GAME_MODE_OPTIONS)[number];
+const CUSTOM_ROOM_KEY_LENGTH_ERROR = `Room id must be ${CUSTOM_ROOM_KEY_MIN_LENGTH} - ${CUSTOM_ROOM_KEY_MAX_LENGTH} characters.`;
 
 function ModeCard({
   mode,
@@ -84,16 +92,30 @@ export function LobbyPage({ onQueue }: { onQueue: (mode: GameMode) => void }) {
   const displayName = useUser((user) => user?.displayName ?? "Commander");
   const resetMatchConnection = useMatchConnectionStore((s) => s.reset);
   const [isCreatingCustom, setIsCreatingCustom] = useState(false);
+  const [customRoomId, setCustomRoomId] = useState("");
   const [customError, setCustomError] = useState<string | null>(null);
   const [isModePickerOpen, setIsModePickerOpen] = useState(false);
 
-  const createCustomRoom = async () => {
+  const createOrJoinCustomRoom = async () => {
+    const trimmedRoomId = customRoomId.trim();
+    if (trimmedRoomId && !isValidCustomRoomKeyLength(trimmedRoomId)) {
+      setCustomError(CUSTOM_ROOM_KEY_LENGTH_ERROR);
+      return;
+    }
     setIsCreatingCustom(true);
     setCustomError(null);
     try {
-      const room = await networkProvider.createCustomRoom();
+      const room = await networkProvider.createCustomRoom(trimmedRoomId);
       navigate(`/match/${encodeURIComponent(room.customRoomKey)}`);
     } catch (error) {
+      if (
+        trimmedRoomId &&
+        error instanceof HttpRequestError &&
+        error.status === 409
+      ) {
+        navigate(`/match/${encodeURIComponent(trimmedRoomId)}`);
+        return;
+      }
       setCustomError(
         error instanceof Error ? error.message : "Failed to create custom room",
       );
@@ -154,19 +176,40 @@ export function LobbyPage({ onQueue }: { onQueue: (mode: GameMode) => void }) {
           </section>
 
           <section className="grid min-h-32 place-items-center border-t border-game-border pt-5 sm:min-h-36">
-            <div className="grid justify-items-center gap-3">
-              <Button
-                type="button"
-                onClick={createCustomRoom}
-                disabled={isCreatingCustom}
-                className="min-w-48 justify-center"
-              >
-                <Plus className="size-4" />
-                {isCreatingCustom ? "Creating..." : "Create custom room"}
-              </Button>
+            <div className="grid w-full justify-items-stretch gap-3">
+              <div className="mx-auto flex w-full max-w-sm flex-col gap-3 sm:flex-row">
+                <Input
+                  value={customRoomId}
+                  onChange={(event) => {
+                    setCustomRoomId(event.target.value);
+                    if (customError) {
+                      setCustomError(null);
+                    }
+                  }}
+                  placeholder="Leave blank to randomize"
+                  aria-label="Custom room id"
+                  autoComplete="off"
+                  className="flex-1 border-game-border bg-game-bg text-game-text placeholder:text-game-text-dim"
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" && !isCreatingCustom) {
+                      event.preventDefault();
+                      void createOrJoinCustomRoom();
+                    }
+                  }}
+                />
+                <Button
+                  type="button"
+                  onClick={() => void createOrJoinCustomRoom()}
+                  disabled={isCreatingCustom}
+                  className="min-w-48 justify-center"
+                >
+                  <Plus className="size-4" />
+                  {isCreatingCustom ? "Creating..." : "Create/Join custom room"}
+                </Button>
+              </div>
 
               {customError ? (
-                <p className="rounded-none border border-destructive/40 p-3 text-sm text-destructive">
+                <p className="mx-auto flex min-h-8 w-full max-w-sm items-center rounded-none border border-destructive/40 px-3 text-sm text-destructive">
                   {customError}
                 </p>
               ) : null}

--- a/apps/client/src/infra/network/provider/colyseus.ts
+++ b/apps/client/src/infra/network/provider/colyseus.ts
@@ -2,6 +2,7 @@ import type { Room } from "@colyseus/sdk";
 import { Client } from "@colyseus/sdk";
 import type {
   CustomRoomCreation,
+  CustomRoomCreationRequest,
   CustomRoomResolution,
   ExtractMessageKey,
   MessagePayload,
@@ -89,6 +90,16 @@ class ColyseusRoomAdapter<
   }
 }
 
+export class HttpRequestError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "HttpRequestError";
+    this.status = status;
+  }
+}
+
 /**
  * Implementation of `NetworkProvider` for the Colyseus SDK.
  */
@@ -141,7 +152,7 @@ export class ColyseusNetworkProvider<User = unknown>
       } catch {
         // Ignore non-JSON error bodies.
       }
-      throw new Error(message);
+      throw new HttpRequestError(response.status, message);
     }
 
     return (await response.json()) as Response;
@@ -231,10 +242,14 @@ export class ColyseusNetworkProvider<User = unknown>
     return new ColyseusRoomAdapter<State, Sent, Received>(room);
   }
 
-  async createCustomRoom(): Promise<CustomRoomCreation> {
+  async createCustomRoom(customRoomKey?: string): Promise<CustomRoomCreation> {
+    const payload: CustomRoomCreationRequest = {};
+    if (customRoomKey?.trim()) {
+      payload.customRoomKey = customRoomKey.trim();
+    }
     return this.requestJson<CustomRoomCreation>("/custom-rooms", {
       method: "POST",
-      body: JSON.stringify({}),
+      body: JSON.stringify(payload),
     });
   }
 

--- a/apps/client/src/infra/network/provider/index.ts
+++ b/apps/client/src/infra/network/provider/index.ts
@@ -41,7 +41,7 @@ export const networkProvider: NetworkProvider<UserProfile> = {
   consumeSeatReservation: (...args) =>
     getNetworkProvider().consumeSeatReservation(...args),
   create: (...args) => getNetworkProvider().create(...args),
-  createCustomRoom: () => getNetworkProvider().createCustomRoom(),
+  createCustomRoom: (...args) => getNetworkProvider().createCustomRoom(...args),
   resolveCustomRoom: (...args) =>
     getNetworkProvider().resolveCustomRoom(...args),
   restoreSession: (...args) => getNetworkProvider().restoreSession(...args),

--- a/apps/client/src/infra/network/provider/interfaces.ts
+++ b/apps/client/src/infra/network/provider/interfaces.ts
@@ -138,7 +138,7 @@ export interface NetworkProvider<User = unknown> {
     options?: Record<string, unknown>,
   ): Promise<RoomClient<State, Sent, Received>>;
 
-  createCustomRoom(): Promise<CustomRoomCreation>;
+  createCustomRoom(customRoomKey?: string): Promise<CustomRoomCreation>;
 
   resolveCustomRoom(customRoomKey: string): Promise<CustomRoomResolution>;
 

--- a/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
+++ b/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
@@ -3,6 +3,8 @@
 import { GameMode } from "@generals-plus/engine";
 import type { SetupSettings } from "@generals-plus/shared-types";
 import {
+  CUSTOM_ROOM_KEY_MAX_LENGTH,
+  CUSTOM_ROOM_KEY_MIN_LENGTH,
   MatchClientMessage,
   MatchServerMessage,
   PLAYER_COLOR_PALETTE,
@@ -29,6 +31,7 @@ import { resetGameConnectionsForTesting } from "#/features/game/api/use-game-roo
 import { resetQueueConnectionsForTesting } from "#/features/game/api/use-queue-room";
 import { resetSetupConnectionsForTesting } from "#/features/game/api/use-setup-room";
 import { QueuePage } from "#/features/game/pages/queue-page";
+import { HttpRequestError } from "#/infra/network/provider/colyseus";
 import { createMockAuth } from "#/tests/helpers/auth";
 import { renderRoute } from "#/tests/helpers/render";
 
@@ -407,7 +410,7 @@ describe("client room flows", () => {
 
     const user = userEvent.setup();
     await user.click(
-      screen.getByRole("button", { name: "Create custom room" }),
+      screen.getByRole("button", { name: "Create/Join custom room" }),
     );
 
     expect(await screen.findByText("You are host")).toBeTruthy();
@@ -417,6 +420,79 @@ describe("client room flows", () => {
     expect(networkMocks.createCustomRoom).toHaveBeenCalledTimes(1);
     expect(networkMocks.resolveCustomRoom).toHaveBeenCalledWith("custom-123");
     expect(networkMocks.joinById).toHaveBeenCalledWith("setup-123");
+  });
+
+  it("joins an existing custom setup room when creating the same lobby room id conflicts", async () => {
+    const setupRoom = createRoom({
+      roomId: "setup-join-existing",
+      state: createSetupState([
+        {
+          id: "player-1",
+          displayName: "Nova",
+          color: PLAYER_COLOR_PALETTE[0],
+          isHost: false,
+        },
+        {
+          id: "player-2",
+          displayName: "Rook",
+          color: PLAYER_COLOR_PALETTE[1],
+          isHost: true,
+        },
+      ]),
+    });
+    networkMocks.createCustomRoom.mockRejectedValue(
+      new HttpRequestError(409, "room already exists"),
+    );
+    networkMocks.resolveCustomRoom.mockResolvedValue({
+      customRoomKey: "existing-room",
+      setupRoomId: "setup-join-existing",
+      created: false,
+    });
+    networkMocks.joinById.mockResolvedValue(setupRoom);
+
+    renderRoute("/", auth());
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByRole("textbox", { name: "Custom room id" }),
+      "existing-room",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Create/Join custom room" }),
+    );
+
+    expect(await screen.findByText("You are guest")).toBeTruthy();
+    expect(networkMocks.createCustomRoom).toHaveBeenCalledWith("existing-room");
+    expect(networkMocks.resolveCustomRoom).toHaveBeenCalledWith(
+      "existing-room",
+    );
+    expect(networkMocks.joinById).toHaveBeenCalledWith("setup-join-existing");
+  });
+
+  it("shows a validation error when the lobby custom room id is too short or too long", async () => {
+    renderRoute("/", auth());
+
+    const user = userEvent.setup();
+    const input = screen.getByRole("textbox", { name: "Custom room id" });
+    const button = screen.getByRole("button", {
+      name: "Create/Join custom room",
+    });
+
+    await user.type(input, "abc");
+    await user.click(button);
+
+    expect(
+      screen.getByText(
+        `Room id must be ${CUSTOM_ROOM_KEY_MIN_LENGTH} - ${CUSTOM_ROOM_KEY_MAX_LENGTH} characters.`,
+      ),
+    ).toBeTruthy();
+    expect(networkMocks.createCustomRoom).not.toHaveBeenCalled();
+
+    await user.clear(input);
+    await user.type(input, "abcdefghijklmnopq");
+    await user.click(button);
+
+    expect(networkMocks.createCustomRoom).not.toHaveBeenCalled();
   });
 
   it("renders custom setup state when the initial room patch arrived before navigation", async () => {
@@ -448,7 +524,7 @@ describe("client room flows", () => {
 
     const user = userEvent.setup();
     await user.click(
-      screen.getByRole("button", { name: "Create custom room" }),
+      screen.getByRole("button", { name: "Create/Join custom room" }),
     );
 
     expect(await screen.findByText("You are host")).toBeTruthy();

--- a/apps/client/tests/routes/index.test.tsx
+++ b/apps/client/tests/routes/index.test.tsx
@@ -57,7 +57,7 @@ describe("index route", () => {
     expect(screen.getByText("Nova")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Start" })).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Create custom room" }),
+      screen.getByRole("button", { name: "Create/Join custom room" }),
     ).toBeTruthy();
   });
 

--- a/apps/server/src/app.config.ts
+++ b/apps/server/src/app.config.ts
@@ -8,6 +8,7 @@ import { defineRoom, LobbyRoom, logger } from "@colyseus/core";
 import { monitor } from "@colyseus/monitor";
 import { Encoder } from "@colyseus/schema";
 import { defineServer, matchMaker } from "colyseus";
+import express from "express";
 import mongoose from "mongoose";
 
 import { ENV } from "#/env";
@@ -84,10 +85,13 @@ export default defineServer({
     // 1. Establish database connection before mounting routes
     await connectDB();
 
-    // 2. Bind Authentication module routes (/auth/register, /auth/login, etc.)
+    // 2. Parse JSON bodies for custom room HTTP endpoints.
+    app.use(express.json());
+
+    // 3. Bind Authentication module routes (/auth/register, /auth/login, etc.)
     app.use(auth.prefix, auth.routes());
 
-    // 3. (Optional) Bind Colyseus Monitor for development debugging
+    // 4. (Optional) Bind Colyseus Monitor for development debugging
     if (process.env.NODE_ENV !== "production") {
       app.use("/colyseus", monitor());
     }

--- a/apps/server/src/features/setup/custom-room-registry.ts
+++ b/apps/server/src/features/setup/custom-room-registry.ts
@@ -10,6 +10,13 @@ interface CustomRoomResolution {
 
 interface CustomRoomCreation extends CustomRoomResolution {}
 
+export class CustomRoomAlreadyExistsError extends Error {
+  constructor(customRoomKey: string) {
+    super(`custom room already exists: ${customRoomKey}`);
+    this.name = "CustomRoomAlreadyExistsError";
+  }
+}
+
 interface CustomRoomRecord {
   key: string;
   activeSetupRoomId: string | null;
@@ -78,10 +85,18 @@ async function createOrJoinPendingSetupRoom(
 
 export async function createCustomRoom(
   ownerUserId: string | null,
+  requestedKey?: string,
 ): Promise<CustomRoomCreation> {
-  let key = generateCustomRoomKey();
-  while (customRooms.has(key)) {
+  let key = requestedKey?.trim() ?? "";
+  if (key) {
+    if (customRooms.has(key)) {
+      throw new CustomRoomAlreadyExistsError(key);
+    }
+  } else {
     key = generateCustomRoomKey();
+    while (customRooms.has(key)) {
+      key = generateCustomRoomKey();
+    }
   }
 
   const setupRoomId = await createSetupRoomForKeyImpl(key);

--- a/apps/server/src/features/setup/custom-room-registry.ts
+++ b/apps/server/src/features/setup/custom-room-registry.ts
@@ -99,15 +99,35 @@ export async function createCustomRoom(
     }
   }
 
-  const setupRoomId = await createSetupRoomForKeyImpl(key);
-  customRooms.set(key, {
+  const record: CustomRoomRecord = {
     key,
-    activeSetupRoomId: setupRoomId,
+    activeSetupRoomId: null,
     pendingSetupRoomId: null,
-    status: "setup",
-    version: 1,
+    status: "idle",
+    version: 0,
     ownerUserId,
-  });
+  };
+  customRooms.set(key, record);
+
+  const pendingSetupRoomId = createSetupRoomForKeyImpl(key)
+    .then((setupRoomId) => {
+      record.activeSetupRoomId = setupRoomId;
+      record.status = "setup";
+      record.version = 1;
+      return setupRoomId;
+    })
+    .catch((error) => {
+      if (customRooms.get(key) === record) {
+        customRooms.delete(key);
+      }
+      throw error;
+    })
+    .finally(() => {
+      record.pendingSetupRoomId = null;
+    });
+
+  record.pendingSetupRoomId = pendingSetupRoomId;
+  const setupRoomId = await pendingSetupRoomId;
 
   return { customRoomKey: key, setupRoomId, created: true };
 }

--- a/apps/server/src/features/setup/custom-room-routes.ts
+++ b/apps/server/src/features/setup/custom-room-routes.ts
@@ -1,7 +1,17 @@
 import { JWT } from "@colyseus/auth";
+import type { CustomRoomCreationRequest } from "@generals-plus/shared-types";
+import {
+  CUSTOM_ROOM_KEY_MAX_LENGTH,
+  CUSTOM_ROOM_KEY_MIN_LENGTH,
+  isValidCustomRoomKeyLength,
+} from "@generals-plus/shared-types";
 import type { Request, Response } from "express";
 
-import { createCustomRoom, resolveCustomRoom } from "./custom-room-registry";
+import {
+  CustomRoomAlreadyExistsError,
+  createCustomRoom,
+  resolveCustomRoom,
+} from "./custom-room-registry";
 
 async function getAuthorizedUserId(request: Request) {
   const header = request.header("authorization");
@@ -17,6 +27,8 @@ async function getAuthorizedUserId(request: Request) {
   }
 }
 
+const CUSTOM_ROOM_KEY_LENGTH_ERROR = `Room id must be ${CUSTOM_ROOM_KEY_MIN_LENGTH} - ${CUSTOM_ROOM_KEY_MAX_LENGTH} characters.`;
+
 export function registerCustomRoomRoutes(app: {
   post: (
     path: string,
@@ -30,7 +42,28 @@ export function registerCustomRoomRoutes(app: {
       return;
     }
 
-    const room = await createCustomRoom(ownerUserId);
+    const requestedKey =
+      (request.body as CustomRoomCreationRequest | undefined)?.customRoomKey ??
+      undefined;
+    if (requestedKey !== undefined && typeof requestedKey !== "string") {
+      response.status(400).json({ error: "Invalid custom room key" });
+      return;
+    }
+    if (requestedKey && !isValidCustomRoomKeyLength(requestedKey.trim())) {
+      response.status(400).json({ error: CUSTOM_ROOM_KEY_LENGTH_ERROR });
+      return;
+    }
+
+    let room = null;
+    try {
+      room = await createCustomRoom(ownerUserId, requestedKey);
+    } catch (error) {
+      if (error instanceof CustomRoomAlreadyExistsError) {
+        response.status(409).json({ error: "room already exists" });
+        return;
+      }
+      throw error;
+    }
     response.status(201).json(room);
   });
 
@@ -46,6 +79,10 @@ export function registerCustomRoomRoutes(app: {
       const customRoomKey = request.params.customRoomKey;
       if (typeof customRoomKey !== "string") {
         response.status(400).json({ error: "Invalid custom room key" });
+        return;
+      }
+      if (!isValidCustomRoomKeyLength(customRoomKey.trim())) {
+        response.status(400).json({ error: CUSTOM_ROOM_KEY_LENGTH_ERROR });
         return;
       }
 

--- a/apps/server/src/features/setup/setup-room.ts
+++ b/apps/server/src/features/setup/setup-room.ts
@@ -148,14 +148,19 @@ export class SetupRoom extends Room<{ state: SetupState }> {
     }
   }
 
-  onLeave(client: Client) {
+  async onLeave(client: Client) {
     const auth = client.auth as ClientAuth;
     const id = auth.id;
     const isHost = id === this.hostId;
 
     this.removePlayerFromState(id);
 
-    if (isHost && this.state.players.length > 0) {
+    if (this.state.players.length === 0) {
+      await this.disconnect();
+      return;
+    }
+
+    if (isHost) {
       this.transferHost();
     }
   }

--- a/apps/server/tests/features/setup/custom-room-registry.test.ts
+++ b/apps/server/tests/features/setup/custom-room-registry.test.ts
@@ -96,6 +96,31 @@ describe("custom room registry", () => {
     ).rejects.toBeInstanceOf(CustomRoomAlreadyExistsError);
   });
 
+  it("atomically reserves a requested key across concurrent creates", async () => {
+    const creationDeferred = createDeferred<string>();
+    let createCount = 0;
+    setCreateSetupRoomForKeyForTesting(async () => {
+      createCount += 1;
+      return creationDeferred.promise;
+    });
+
+    const firstCreate = createCustomRoom("host-1", "shared-room");
+    await Promise.resolve();
+
+    await expect(
+      createCustomRoom("host-2", "shared-room"),
+    ).rejects.toBeInstanceOf(CustomRoomAlreadyExistsError);
+    expect(createCount).toBe(1);
+
+    creationDeferred.resolve("setup-shared");
+
+    await expect(firstCreate).resolves.toEqual({
+      customRoomKey: "shared-room",
+      setupRoomId: "setup-shared",
+      created: true,
+    });
+  });
+
   // --- Coverage for lines 29-34: real createSetupRoomForKey implementation ---
 
   describe("createCustomRoom (real implementation)", () => {

--- a/apps/server/tests/features/setup/custom-room-registry.test.ts
+++ b/apps/server/tests/features/setup/custom-room-registry.test.ts
@@ -2,6 +2,7 @@ import { matchMaker } from "@colyseus/core";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  CustomRoomAlreadyExistsError,
   createCustomRoom,
   markCustomRoomMatchStarted,
   onSetupRoomDisposed,
@@ -70,6 +71,29 @@ describe("custom room registry", () => {
       setupRoomId: "setup-rematch",
       created: false,
     });
+  });
+
+  it("creates a custom room with a requested key", async () => {
+    setCreateSetupRoomForKeyForTesting(async (customRoomKey) => {
+      expect(customRoomKey).toBe("my-room");
+      return "setup-my-room";
+    });
+
+    await expect(createCustomRoom("host-1", "my-room")).resolves.toEqual({
+      customRoomKey: "my-room",
+      setupRoomId: "setup-my-room",
+      created: true,
+    });
+  });
+
+  it("rejects duplicate requested custom room keys", async () => {
+    setCreateSetupRoomForKeyForTesting(async () => "setup-abc");
+
+    await createCustomRoom("host-1", "taken-room");
+
+    await expect(
+      createCustomRoom("host-2", "taken-room"),
+    ).rejects.toBeInstanceOf(CustomRoomAlreadyExistsError);
   });
 
   // --- Coverage for lines 29-34: real createSetupRoomForKey implementation ---

--- a/packages/shared-types/src/custom-room.ts
+++ b/packages/shared-types/src/custom-room.ts
@@ -1,3 +1,6 @@
+export const CUSTOM_ROOM_KEY_MIN_LENGTH = 4;
+export const CUSTOM_ROOM_KEY_MAX_LENGTH = 16;
+
 export interface CustomRoomResolution {
   customRoomKey: string;
   setupRoomId: string;
@@ -5,3 +8,14 @@ export interface CustomRoomResolution {
 }
 
 export interface CustomRoomCreation extends CustomRoomResolution {}
+
+export interface CustomRoomCreationRequest {
+  customRoomKey?: string;
+}
+
+export function isValidCustomRoomKeyLength(customRoomKey: string) {
+  return (
+    customRoomKey.length >= CUSTOM_ROOM_KEY_MIN_LENGTH &&
+    customRoomKey.length <= CUSTOM_ROOM_KEY_MAX_LENGTH
+  );
+}


### PR DESCRIPTION
Closes #101.

This pull request implements significant improvements to the custom room creation and joining flow, enhancing both backend validation and the client-side experience. The main changes include allowing users to specify custom room IDs with validation, handling conflicts when a room already exists, improving error messaging, and updating tests to cover new behaviors. Additionally, backend routes now enforce stricter validation and error handling for custom room keys.

**Custom Room Creation & Joining Flow Improvements:**

- The client now allows users to specify a custom room ID when creating or joining a room, with validation for minimum and maximum length. If the specified ID already exists, the client automatically attempts to join the existing room instead of failing. Error messages are more descriptive, and the UI reflects these changes [[1]](diffhunk://#diff-f6d88e6b7eb025c016bc28539b057b487d6fa728cae070556aadb9ac873a0938R2-R6) [[2]](diffhunk://#diff-f6d88e6b7eb025c016bc28539b057b487d6fa728cae070556aadb9ac873a0938R19-R28) [[3]](diffhunk://#diff-f6d88e6b7eb025c016bc28539b057b487d6fa728cae070556aadb9ac873a0938R95-R118) [[4]](diffhunk://#diff-f6d88e6b7eb025c016bc28539b057b487d6fa728cae070556aadb9ac873a0938L157-R212).

- The backend (`custom-room-registry` and `custom-room-routes`) now validates custom room key length, returns a 409 error if the room already exists, and provides clear error messages for invalid input. A custom error class is introduced for room conflicts [[1]](diffhunk://#diff-c05668063029d77b1c51115b59e556a47fab7cbb0773ffe0e41bfea1965cc494R2-R14) [[2]](diffhunk://#diff-c05668063029d77b1c51115b59e556a47fab7cbb0773ffe0e41bfea1965cc494R30-R31) [[3]](diffhunk://#diff-c05668063029d77b1c51115b59e556a47fab7cbb0773ffe0e41bfea1965cc494L33-R66) [[4]](diffhunk://#diff-c05668063029d77b1c51115b59e556a47fab7cbb0773ffe0e41bfea1965cc494R84-R87) [[5]](diffhunk://#diff-d5c9c1571cbc0a3d65289df33970c0afde9b229ecc80cdce5e330c9a7b4465d4R13-R19) [[6]](diffhunk://#diff-d5c9c1571cbc0a3d65289df33970c0afde9b229ecc80cdce5e330c9a7b4465d4R88-R100).

**Network Provider & Error Handling:**

- The network provider interface and implementation are updated to accept an optional custom room key parameter and to throw a specialized `HttpRequestError` with status codes for better client-side error handling [[1]](diffhunk://#diff-38edee62de1c64e9f5d9e2d2441bf5a72394d3da490c682dcf7c8d7ac63c546fR5) [[2]](diffhunk://#diff-38edee62de1c64e9f5d9e2d2441bf5a72394d3da490c682dcf7c8d7ac63c546fR93-R102) [[3]](diffhunk://#diff-38edee62de1c64e9f5d9e2d2441bf5a72394d3da490c682dcf7c8d7ac63c546fL144-R155) [[4]](diffhunk://#diff-38edee62de1c64e9f5d9e2d2441bf5a72394d3da490c682dcf7c8d7ac63c546fL234-R252) [[5]](diffhunk://#diff-15a414e3bcfec30c1562423afda8d82b96d267eff624dde20b0b88f59586dceeL44-R44) [[6]](diffhunk://#diff-4c1ffa1a4dc7553d33987a49560bf25976d8167ed1c29a1899c8acc11c98b1edL141-R141).

**Testing Enhancements:**

- End-to-end and unit tests are updated to reflect the new create/join custom room flow, including validation errors and conflict resolution. New test cases are added to ensure correct behavior when joining existing rooms and when inputting invalid room IDs [[1]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fR6-R7) [[2]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fR34) [[3]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fL410-R413) [[4]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fR425-R497) [[5]](diffhunk://#diff-c8bcc2c444894dac0af27262b13ac42303d8ebddf2520250cf46e1b1eb69a48fL451-R527) [[6]](diffhunk://#diff-4189c4a444fc79b591cf595f84231b2f9dedb972eae62570480c3938883bce78L60-R60).

**Server and Routing Infrastructure:**

- The server is updated to parse JSON bodies for custom room HTTP endpoints, ensuring correct request handling [[1]](diffhunk://#diff-d27009bcf67853733d5e1b11338ff5b480ef1e22b720fc939cc8737b1bf2682aR11) [[2]](diffhunk://#diff-d27009bcf67853733d5e1b11338ff5b480ef1e22b720fc939cc8737b1bf2682aL87-R94).

**Setup Room Cleanup:**

- The setup room now disconnects itself if all players leave, ensuring proper cleanup of unused rooms.