### PR TITLE
fix(client/scoreboard): sort players in scoreboard and make eliminated player gray

### DIFF
--- a/apps/client/src/features/game/components/game-hud.tsx
+++ b/apps/client/src/features/game/components/game-hud.tsx
@@ -132,17 +132,21 @@ export function GameHud({ scoreboard, timer, targetScore }: GameHudProps) {
                         className="flex items-center gap-1.5 min-w-0 text-[13px] font-normal tracking-wide"
                       >
                         <span
-                          className="size-2.5 shrink-0"
+                          className={`size-2.5 shrink-0 ${player.isAlive ? "" : "opacity-40"}`}
                           style={{ backgroundColor: colorToHex(player.color) }}
                         />
-                        <span className="truncate">{player.label}</span>
+                        <span
+                          className={`truncate ${player.isAlive ? "" : "text-game-text-dim/50"}`}
+                        >
+                          {player.label}
+                        </span>
                       </div>,
                     );
                     scoreboardModel.columns.forEach((column) => {
                       groupRows.push(
                         <span
                           key={`player-metric-${player.id}-${column.key}`}
-                          className="text-right tabular-nums text-[13px] font-normal"
+                          className={`text-right tabular-nums text-[13px] font-normal ${player.isAlive ? "" : "text-game-text-dim/50"}`}
                         >
                           {formatValue(player.values?.[column.key])}
                         </span>,
@@ -172,17 +176,21 @@ export function GameHud({ scoreboard, timer, targetScore }: GameHudProps) {
                       className="flex items-center gap-1.5 min-w-0 text-[13px] font-normal tracking-wide"
                     >
                       <span
-                        className="size-2.5 shrink-0"
+                        className={`size-2.5 shrink-0 ${player.isAlive ? "" : "opacity-40"}`}
                         style={{ backgroundColor: colorToHex(player.color) }}
                       />
-                      <span className="truncate">{player.label}</span>
+                      <span
+                        className={`truncate ${player.isAlive ? "" : "text-game-text-dim/50"}`}
+                      >
+                        {player.label}
+                      </span>
                     </div>,
                   );
                   scoreboardModel.columns.forEach((column) => {
                     playerRows.push(
                       <span
                         key={`player-metric-${player.id}-${column.key}`}
-                        className="text-right tabular-nums text-[13px] font-normal"
+                        className={`text-right tabular-nums text-[13px] font-normal ${player.isAlive ? "" : "text-game-text-dim/50"}`}
                       >
                         {formatValue(player.values?.[column.key])}
                       </span>,

--- a/apps/client/src/features/game/components/game-hud.tsx
+++ b/apps/client/src/features/game/components/game-hud.tsx
@@ -42,7 +42,13 @@ function formatValue(value: number | string | undefined) {
 export function GameHud({ scoreboard, timer, targetScore }: GameHudProps) {
   const scoreboardModel = createGameHudScoreboardModel(scoreboard, targetScore);
   const shouldShowGroupRows = scoreboardModel.hasTeams;
-  const ungroupedRows = scoreboardModel.groups.flatMap((group) => group.rows);
+  const ungroupedRows = scoreboardModel.groups
+    .flatMap((group) => group.rows)
+    .sort(
+      (a, b) =>
+        Number(b.values.troops) - Number(a.values.troops) ||
+        a.label.localeCompare(b.label),
+    );
   const shouldShowTimer =
     timer && timer.targetTick > 0 && timer.tickInterval > 0;
 

--- a/apps/client/src/features/match/utils/scoreboard-adapter.ts
+++ b/apps/client/src/features/match/utils/scoreboard-adapter.ts
@@ -25,6 +25,8 @@ export interface GameHudRow {
   color: number;
   /** Metric values keyed by {@link GameHudColumn.key}. */
   values: Record<string, number | string>;
+  /** Whether the player is alive. */
+  isAlive: boolean;
 }
 
 /**
@@ -64,6 +66,7 @@ interface TroopLandScoreEntry {
   color?: number;
   land: number;
   troops: number;
+  isAlive?: boolean;
 }
 
 interface TeamScoreEntry {
@@ -136,6 +139,7 @@ function getTroopLandEntries(scoreboard: BaseScoreboard) {
         color: entry.color,
         land: entry.land,
         troops: entry.troops,
+        isAlive: (entry as unknown as { isAlive?: boolean }).isAlive ?? true,
       }))
     : [];
 }
@@ -204,6 +208,7 @@ function createPlayerRows(scoreboard: BaseScoreboard): GameHudRow[] {
           land: score.land,
           troops: score.troops,
         },
+        isAlive: score.isAlive ?? true,
       };
     })
     .sort(

--- a/apps/client/src/features/match/utils/scoreboard-adapter.ts
+++ b/apps/client/src/features/match/utils/scoreboard-adapter.ts
@@ -219,6 +219,20 @@ function createPlayerRows(scoreboard: BaseScoreboard): GameHudRow[] {
 }
 
 /**
+ * Prettifies raw team identifiers (e.g. "team_0" -> "Team 1").
+ */
+function formatTeamLabel(teamId: string): string {
+  if (teamId.startsWith("team_")) {
+    const numPart = teamId.substring("team_".length);
+    const num = Number.parseInt(numPart, 10);
+    if (!Number.isNaN(num)) {
+      return `Team ${num + 1}`;
+    }
+  }
+  return `Team ${teamId}`;
+}
+
+/**
  * Groups player rows by team and computes troop/land totals for each group.
  */
 function createTeamGroups(rows: GameHudRow[]) {
@@ -228,7 +242,7 @@ function createTeamGroups(rows: GameHudRow[]) {
     const teamId = row.teamId || row.id;
     const group = groups.get(teamId) ?? {
       id: teamId,
-      label: row.teamId ? `Team ${teamId}` : "Unassigned",
+      label: row.teamId ? formatTeamLabel(row.teamId) : "Unassigned",
       totals: { land: 0, troops: 0 },
       rows: [],
     };
@@ -248,6 +262,20 @@ function createTeamGroups(rows: GameHudRow[]) {
 }
 
 /**
+ * Detects whether the scoreboard is a team game by checking if any teamId is
+ * shared by more than one player.
+ */
+function checkHasTeams(rows: GameHudRow[]): boolean {
+  const teamCounts = new Map<string, number>();
+  for (const row of rows) {
+    if (row.teamId) {
+      teamCounts.set(row.teamId, (teamCounts.get(row.teamId) ?? 0) + 1);
+    }
+  }
+  return Array.from(teamCounts.values()).some((count) => count > 1);
+}
+
+/**
  * Creates a HUD model for modes whose scoreboard is based on land and soldiers.
  */
 function createTroopLandModel(
@@ -255,6 +283,7 @@ function createTroopLandModel(
   scoreboard: BaseScoreboard,
 ): GameHudScoreboardModel {
   const rows = createPlayerRows(scoreboard);
+  const hasTeams = checkHasTeams(rows);
   return {
     title,
     columns: troopLandColumns,
@@ -263,7 +292,7 @@ function createTroopLandModel(
         Number(b.totals?.troops ?? 0) - Number(a.totals?.troops ?? 0) ||
         a.label.localeCompare(b.label),
     ),
-    hasTeams: false,
+    hasTeams,
   };
 }
 

--- a/apps/client/src/features/match/utils/scoreboard-adapter.ts
+++ b/apps/client/src/features/match/utils/scoreboard-adapter.ts
@@ -253,7 +253,11 @@ function createTroopLandModel(
   return {
     title,
     columns: troopLandColumns,
-    groups: createTeamGroups(rows),
+    groups: createTeamGroups(rows).sort(
+      (a, b) =>
+        Number(b.totals?.troops ?? 0) - Number(a.totals?.troops ?? 0) ||
+        a.label.localeCompare(b.label),
+    ),
     hasTeams: false,
   };
 }

--- a/apps/client/tests/features/match/utils/scoreboard-adapter.test.ts
+++ b/apps/client/tests/features/match/utils/scoreboard-adapter.test.ts
@@ -231,4 +231,25 @@ describe("createGameHudScoreboardModel", () => {
       values: { land: 8, troops: 15 },
     });
   });
+
+  it("adapts classic troop-land scoreboard rows with dead player", () => {
+    const scoreboard = new ClassicScoreboard();
+    scoreboard.mode = GameMode.CLASSIC;
+
+    const p1 = playerScore({
+      playerId: "p1",
+      teamId: "p1",
+      displayName: "Nova",
+      troops: 0,
+      land: 0,
+    });
+    const entry1 = new ClassicScoreboardPlayerEntry();
+    Object.assign(entry1, p1, { isAlive: false });
+
+    scoreboard.players.push(entry1);
+
+    const model = createGameHudScoreboardModel(scoreboard);
+
+    expect(model.groups[0].rows[0].isAlive).toBe(false);
+  });
 });

--- a/apps/client/tests/features/match/utils/scoreboard-adapter.test.ts
+++ b/apps/client/tests/features/match/utils/scoreboard-adapter.test.ts
@@ -252,4 +252,58 @@ describe("createGameHudScoreboardModel", () => {
 
     expect(model.groups[0].rows[0].isAlive).toBe(false);
   });
+
+  it("adapts classic troop-land scoreboard in team mode", () => {
+    const scoreboard = new ClassicScoreboard();
+    scoreboard.mode = GameMode.CLASSIC;
+
+    // Two players on team_0 (total 35 troops)
+    const p1 = playerScore({
+      playerId: "p1",
+      teamId: "team_0",
+      displayName: "Nova",
+      troops: 10,
+      land: 4,
+    });
+    const entry1 = new ClassicScoreboardPlayerEntry();
+    Object.assign(entry1, p1, { isAlive: true });
+
+    const p2 = playerScore({
+      playerId: "p2",
+      teamId: "team_0",
+      displayName: "Astra",
+      troops: 25,
+      land: 2,
+    });
+    const entry2 = new ClassicScoreboardPlayerEntry();
+    Object.assign(entry2, p2, { isAlive: true });
+
+    // One player on team_1 (total 30 troops)
+    const p3 = playerScore({
+      playerId: "p3",
+      teamId: "team_1",
+      displayName: "Rook",
+      troops: 30,
+      land: 5,
+    });
+    const entry3 = new ClassicScoreboardPlayerEntry();
+    Object.assign(entry3, p3, { isAlive: true });
+
+    scoreboard.players.push(entry1, entry2, entry3);
+
+    const model = createGameHudScoreboardModel(scoreboard);
+
+    expect(model.hasTeams).toBe(true);
+    expect(model.groups).toHaveLength(2);
+
+    const g1 = model.groups[0];
+    expect(g1.id).toBe("team_0");
+    expect(g1.label).toBe("Team 1");
+    expect(g1.totals?.troops).toBe(35);
+
+    const g2 = model.groups[1];
+    expect(g2.id).toBe("team_1");
+    expect(g2.label).toBe("Team 2");
+    expect(g2.totals?.troops).toBe(30);
+  });
 });

--- a/apps/client/tests/features/match/utils/scoreboard-adapter.test.ts
+++ b/apps/client/tests/features/match/utils/scoreboard-adapter.test.ts
@@ -117,6 +117,41 @@ describe("createGameHudScoreboardModel", () => {
     });
   });
 
+  it("adapts classic troop-land scoreboard rows sorted by troops descending", () => {
+    const scoreboard = new ClassicScoreboard();
+    scoreboard.mode = GameMode.CLASSIC;
+
+    const p1 = playerScore({
+      playerId: "p1",
+      teamId: "p1",
+      displayName: "Nova",
+      troops: 10,
+      land: 4,
+    });
+    const entry1 = new ClassicScoreboardPlayerEntry();
+    Object.assign(entry1, p1, { isAlive: true });
+
+    const p2 = playerScore({
+      playerId: "p2",
+      teamId: "p2",
+      displayName: "Astra",
+      troops: 25,
+      land: 2,
+    });
+    const entry2 = new ClassicScoreboardPlayerEntry();
+    Object.assign(entry2, p2, { isAlive: true });
+
+    scoreboard.players.push(entry1, entry2);
+
+    const model = createGameHudScoreboardModel(scoreboard);
+
+    expect(model.title).toBe("Classic");
+    expect(model.groups).toHaveLength(2);
+    // p2 has 25 troops, p1 has 10 troops -> p2 should be first!
+    expect(model.groups[0].id).toBe("p2");
+    expect(model.groups[1].id).toBe("p1");
+  });
+
   it("adapts turf war scoreboard rows grouped by team with percentage", () => {
     const model = createGameHudScoreboardModel(turfWarScoreboard());
 


### PR DESCRIPTION
Closes #109 .

This pull request improves how player status (alive or dead) is handled and displayed in the game HUD scoreboard. It introduces an `isAlive` property to player data, updates the UI to visually distinguish dead players, and ensures scoreboard groups are sorted by troop count. Comprehensive tests are added to verify these behaviors.

**Scoreboard Data Model Enhancements:**

* Added an `isAlive` boolean property to the `GameHudRow` interface and related types to track player status. [[1]](diffhunk://#diff-e9925a242cdab83365e6e61e005488714c44d14cac9f272e007680ae99bc3c43R28-R29) [[2]](diffhunk://#diff-e9925a242cdab83365e6e61e005488714c44d14cac9f272e007680ae99bc3c43R69)
* Updated data transformation functions (`getTroopLandEntries`, `createPlayerRows`) to set `isAlive`, defaulting to `true` if not specified. [[1]](diffhunk://#diff-e9925a242cdab83365e6e61e005488714c44d14cac9f272e007680ae99bc3c43R142) [[2]](diffhunk://#diff-e9925a242cdab83365e6e61e005488714c44d14cac9f272e007680ae99bc3c43R211)

**Scoreboard Sorting Improvements:**

* Modified `createTroopLandModel` to sort scoreboard groups by descending troop count, with a secondary sort by label.

**UI/UX Updates in Game HUD:**

* Updated `game-hud.tsx` to visually indicate dead players by reducing avatar opacity and dimming text color for their name and stats. [[1]](diffhunk://#diff-b63ee8f63e3bfab70d888e16fdabf19a36586e2418ffc14c066c094361c7ccdeL135-R149) [[2]](diffhunk://#diff-b63ee8f63e3bfab70d888e16fdabf19a36586e2418ffc14c066c094361c7ccdeL175-R193)

**Testing and Verification:**

* Added tests to verify correct sorting of scoreboard groups by troop count and to ensure dead players are correctly marked and rendered in the scoreboard model. [[1]](diffhunk://#diff-6677f47fd20266bb35ca92f4953aaeb94e12d2b743d81c86cda0186b740c46deR120-R154) [[2]](diffhunk://#diff-6677f47fd20266bb35ca92f4953aaeb94e12d2b743d81c86cda0186b740c46deR234-R254)