### PR TITLE
fix(server): default value deliver through QueueRoom

### DIFF
--- a/apps/server/src/features/queue/queue-room.ts
+++ b/apps/server/src/features/queue/queue-room.ts
@@ -22,17 +22,16 @@ const DEFAULT_COUNTDOWN_CYCLES = 20;
 const BASE_TICK_INTERVAL = 500;
 const RATING_TOLERANCE = 200;
 
-const MODE_SETTINGS: Record<
-  string,
-  { duration?: number; flagCount?: number; targetScore?: number }
-> = {
-  domination: { duration: 300, flagCount: 3, targetScore: 1000 },
-  turf_war: { duration: 180 },
-};
-
-function calculateTickInterval(speed: number): number {
-  return Math.max(100, Math.round(BASE_TICK_INTERVAL / speed));
+interface ModeSettings {
+  duration?: number;
+  flagCount?: number;
+  targetScore?: number;
 }
+
+const MODE_SETTINGS = {
+  [GameMode.DOMINATION]: { duration: 300, flagCount: 3, targetScore: 1000 },
+  [GameMode.TURF_WAR]: { duration: 180 },
+} satisfies Partial<Record<GameMode, ModeSettings>>;
 
 function calculateFinishTick(duration: number, tickInterval: number): number {
   return Math.round((duration * 1000) / tickInterval);
@@ -86,7 +85,9 @@ export class MatchQueueRoom extends QueueRoom {
           groupPlayerIds.includes(p.id),
         );
 
-        const modeSettings = MODE_SETTINGS[this.gameMode];
+        const modeSettings = (
+          MODE_SETTINGS as Partial<Record<GameMode, ModeSettings>>
+        )[this.gameMode];
         const gridOptions =
           this.gameMode === GameMode.DOMINATION
             ? ({
@@ -96,9 +97,8 @@ export class MatchQueueRoom extends QueueRoom {
               } as DominationGridOptions)
             : { generalCount: groupPlayers.length, seed: generateSeed() };
 
-        const tickInterval = calculateTickInterval(1);
         const finishTick = modeSettings?.duration
-          ? calculateFinishTick(modeSettings.duration, tickInterval)
+          ? calculateFinishTick(modeSettings.duration, BASE_TICK_INTERVAL)
           : undefined;
 
         const base = {
@@ -141,7 +141,7 @@ export class MatchQueueRoom extends QueueRoom {
           mode: this.gameMode,
           game,
           playerInit,
-          tickInterval,
+          tickInterval: BASE_TICK_INTERVAL,
           finishTick: isTimedMode ? finishTick : undefined,
           targetScore:
             this.gameMode === GameMode.DOMINATION

--- a/apps/server/src/features/queue/queue-room.ts
+++ b/apps/server/src/features/queue/queue-room.ts
@@ -19,7 +19,24 @@ import { MongoUserRepository } from "#/infra/db/repositories/MongoUserRepository
 const DEFAULT_MAX_PLAYERS = 8;
 const DEFAULT_MIN_PLAYERS = 2;
 const DEFAULT_COUNTDOWN_CYCLES = 20;
+const BASE_TICK_INTERVAL = 500;
 const RATING_TOLERANCE = 200;
+
+const MODE_SETTINGS: Record<
+  string,
+  { duration?: number; flagCount?: number; targetScore?: number }
+> = {
+  domination: { duration: 300, flagCount: 3, targetScore: 1000 },
+  turf_war: { duration: 180 },
+};
+
+function calculateTickInterval(speed: number): number {
+  return Math.max(100, Math.round(BASE_TICK_INTERVAL / speed));
+}
+
+function calculateFinishTick(duration: number, tickInterval: number): number {
+  return Math.round((duration * 1000) / tickInterval);
+}
 
 const userRepository = new MongoUserRepository();
 
@@ -69,28 +86,67 @@ export class MatchQueueRoom extends QueueRoom {
           groupPlayerIds.includes(p.id),
         );
 
+        const modeSettings = MODE_SETTINGS[this.gameMode];
         const gridOptions =
           this.gameMode === GameMode.DOMINATION
             ? ({
                 generalCount: groupPlayers.length,
-                flagCount: 3,
+                flagCount: modeSettings?.flagCount ?? 3,
                 seed: generateSeed(),
               } as DominationGridOptions)
             : { generalCount: groupPlayers.length, seed: generateSeed() };
 
-        const game = createGame({
-          mode: this.gameMode,
+        const tickInterval = calculateTickInterval(1);
+        const finishTick = modeSettings?.duration
+          ? calculateFinishTick(modeSettings.duration, tickInterval)
+          : undefined;
+
+        const base = {
           gridOptions,
           playerIds: groupPlayers.map((p) => p.id),
           playerPerTeam: getDefaultPlayersPerTeam(this.gameMode),
-        });
+        };
+
+        const gameOptions = (() => {
+          switch (this.gameMode) {
+            case GameMode.CLASSIC:
+              return { ...base, mode: GameMode.CLASSIC };
+            case GameMode.TURF_WAR:
+              return {
+                ...base,
+                mode: GameMode.TURF_WAR,
+                finishTick,
+              };
+            case GameMode.DOMINATION:
+              return {
+                ...base,
+                mode: GameMode.DOMINATION,
+                finishTick,
+                targetScore: modeSettings?.targetScore,
+              };
+            default:
+              return { ...base, mode: this.gameMode };
+          }
+        })();
+
+        const game = createGame(gameOptions);
 
         const playerInit = createPlayerInit(groupPlayers, game);
+
+        const isTimedMode =
+          this.gameMode === GameMode.TURF_WAR ||
+          this.gameMode === GameMode.DOMINATION;
 
         const metadata: RoomData = {
           mode: this.gameMode,
           game,
           playerInit,
+          tickInterval,
+          finishTick: isTimedMode ? finishTick : undefined,
+          targetScore:
+            this.gameMode === GameMode.DOMINATION
+              ? modeSettings?.targetScore
+              : undefined,
         };
 
         return matchMaker.createRoom(ROOM_NAMES.MATCH, { metadata });

--- a/apps/server/tests/features/queue/queue-room.test.ts
+++ b/apps/server/tests/features/queue/queue-room.test.ts
@@ -311,6 +311,52 @@ describe("MatchQueueRoom", () => {
     });
   });
 
+  describe("mode defaults", () => {
+    async function triggerMatch(gameMode: GameMode) {
+      room = await createRoom<MatchQueueRoom>(ROOM_NAMES.QUEUE, {
+        gameMode,
+        countdownCycles: 2,
+      });
+
+      const c1 = await connectClient(room, { id: "p1", email: "p1@t.com" });
+      c1.userData.rank = 1000;
+      const c2 = await connectClient(room, { id: "p2", email: "p2@t.com" });
+      c2.userData.rank = 1100;
+
+      for (let i = 0; i < 10; i++) {
+        room.reassignMatchGroups();
+      }
+
+      return mocks.createGame.mock.calls[
+        mocks.createGame.mock.calls.length - 1
+      ][0];
+    }
+
+    it("passes finishTick and targetScore for domination mode", async () => {
+      const options = await triggerMatch(GameMode.DOMINATION);
+
+      expect(options.mode).toBe(GameMode.DOMINATION);
+      expect(options.finishTick).toBe(600);
+      expect(options.targetScore).toBe(1000);
+    });
+
+    it("passes finishTick for turf_war mode", async () => {
+      const options = await triggerMatch(GameMode.TURF_WAR);
+
+      expect(options.mode).toBe(GameMode.TURF_WAR);
+      expect(options.finishTick).toBe(360);
+      expect(options.targetScore).toBeUndefined();
+    });
+
+    it("omits finishTick and targetScore for classic mode", async () => {
+      const options = await triggerMatch(GameMode.CLASSIC);
+
+      expect(options.mode).toBe(GameMode.CLASSIC);
+      expect(options.finishTick).toBeUndefined();
+      expect(options.targetScore).toBeUndefined();
+    });
+  });
+
   describe("duplicate connection handling", () => {
     it("kicks old session when same player reconnects", async () => {
       room = await createRoom<MatchQueueRoom>(ROOM_NAMES.QUEUE, {


### PR DESCRIPTION
Closes #124.

This pull request introduces configurable game mode settings and dynamic timing logic to the queue room system, allowing for more flexible and maintainable handling of different game types. The main changes include the introduction of a `MODE_SETTINGS` configuration object, utility functions for tick interval and finish tick calculations, and refactoring of game initialization to use these new settings.

**Game mode configuration and timing improvements:**

* Added a `MODE_SETTINGS` object to centralize per-mode settings such as `duration`, `flagCount`, and `targetScore`, making it easier to adjust or add modes in the future.
* Introduced utility functions `calculateTickInterval` and `calculateFinishTick` to dynamically compute tick intervals and game end conditions based on mode settings.
* Refactored the game initialization logic in `MatchQueueRoom` to use the new `MODE_SETTINGS` and utility functions, enabling dynamic assignment of `flagCount`, `finishTick`, and `targetScore` depending on the selected game mode.
* Updated the `metadata` object passed to the matchmaker to include `tickInterval`, `finishTick`, and `targetScore` where appropriate, improving downstream access to game configuration.