### PR TITLE
fix(client): blur effect in background

### DIFF
--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -186,7 +186,6 @@ body {
   inset: 0;
   pointer-events: none;
   background: rgb(255 255 255 / 0.04);
-  opacity: 1;
   content: "";
 }
 

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -177,8 +177,8 @@ body {
     inset 1px 0 0 rgb(255 255 255 / 0.08),
     inset -1px 0 0 rgb(255 255 255 / 0.05),
     0 24px 80px rgb(0 0 0 / 0.28);
-  backdrop-filter: blur(18px) saturate(118%);
   -webkit-backdrop-filter: blur(18px) saturate(118%);
+  backdrop-filter: blur(18px) saturate(118%);
 }
 
 .stage-center-backdrop::after {

--- a/apps/client/src/index.css
+++ b/apps/client/src/index.css
@@ -172,16 +172,7 @@ body {
   transform: translateX(-50%);
   pointer-events: none;
   border-inline: 1px solid rgb(52 52 52 / 0.72);
-  background:
-    linear-gradient(
-      90deg,
-      rgb(255 255 255 / 0.03) 0%,
-      rgb(27 27 27 / 0.5) 13%,
-      rgb(27 27 27 / 0.68) 50%,
-      rgb(27 27 27 / 0.5) 87%,
-      rgb(255 255 255 / 0.03) 100%
-    ),
-    rgb(27 27 27 / 0.42);
+  background: rgb(27 27 27 / 0.58);
   box-shadow:
     inset 1px 0 0 rgb(255 255 255 / 0.08),
     inset -1px 0 0 rgb(255 255 255 / 0.05),
@@ -194,24 +185,8 @@ body {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background:
-    linear-gradient(
-      90deg,
-      transparent 0%,
-      rgb(255 255 255 / 0.055) 36%,
-      rgb(255 255 255 / 0.12) 50%,
-      rgb(255 255 255 / 0.055) 64%,
-      transparent 100%
-    ),
-    linear-gradient(
-      180deg,
-      rgb(255 255 255 / 0.08) 0%,
-      transparent 18%,
-      transparent 82%,
-      rgb(0 0 0 / 0.16) 100%
-    );
-  mix-blend-mode: screen;
-  opacity: 0.58;
+  background: rgb(255 255 255 / 0.04);
+  opacity: 1;
   content: "";
 }
 


### PR DESCRIPTION
Closes #127.

This pull request simplifies the background styling for the main `body` element and the `.stage-center-backdrop::after` pseudo-element in `index.css`. The changes primarily remove complex gradient backgrounds in favor of solid color backgrounds, and adjust opacity and blend modes for a more straightforward appearance.

**Simplification of background styles:**

* Replaced the complex multi-stop linear gradient background on `body` with a single solid color (`rgb(27 27 27 / 0.58)`), and removed an extra background layer.
* Simplified the `.stage-center-backdrop::after` background from layered gradients and blend modes to a single solid color (`rgb(255 255 255 / 0.04)`) with full opacity, removing `mix-blend-mode` and adjusting `opacity`.

**Consistency improvements:**

* Corrected the order of `backdrop-filter` and `-webkit-backdrop-filter` properties to ensure consistent browser compatibility.