### PR TITLE
fix(client): checkout message support for team mode

### DIFF
--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -53,6 +53,34 @@ interface GamePageProps {
   source: GamePageSource;
 }
 
+interface PublicPlayerLike {
+  id: string;
+  teamId: string;
+  displayName?: string;
+}
+
+function formatTeamLabel(teamId: string): string {
+  if (teamId.startsWith("team_")) {
+    const num = Number.parseInt(teamId.substring("team_".length), 10);
+    if (!Number.isNaN(num)) {
+      return `Team ${num + 1}`;
+    }
+  }
+  return `Team ${teamId}`;
+}
+
+function getTeamMembers(
+  players: Iterable<PublicPlayerLike>,
+  teamId: string,
+  playerNames: Map<string, string>,
+) {
+  return Array.from(players)
+    .filter((player) => player.teamId === teamId)
+    .map(
+      (player) => playerNames.get(player.id) ?? player.displayName ?? player.id,
+    );
+}
+
 /**
  * Match view rendered after queue/setup hands the client a seat reservation.
  *
@@ -312,15 +340,19 @@ export function GamePage({ connection, source }: GamePageProps) {
     Boolean(gameResult) ||
     isPlayerEliminated ||
     Boolean(disconnectMessage);
-  const winnerId = gameResult?.winnerTeamId
-    ? Array.from(gameState.publicPlayers.values()).find(
-        (p) => p.teamId === gameResult.winnerTeamId,
-      )?.id
-    : null;
-  const winnerName = winnerId ? playerNames.get(winnerId) : null;
+  const winnerTeamId = gameResult?.winnerTeamId ?? null;
+  const winnerTeamMembers = winnerTeamId
+    ? getTeamMembers(
+        gameState.publicPlayers.values(),
+        winnerTeamId,
+        playerNames,
+      )
+    : [];
+  const isTeamResult = winnerTeamMembers.length > 1;
+  const winnerName = winnerTeamMembers[0] ?? null;
+  const winnerTeamLabel = winnerTeamId ? formatTeamLabel(winnerTeamId) : null;
   const didWin = Boolean(
-    gameResult?.winnerTeamId &&
-      currentPlayer?.teamId === gameResult.winnerTeamId,
+    winnerTeamId && currentPlayer?.teamId === winnerTeamId,
   );
   const activeModal = disconnectMessage
     ? null
@@ -495,20 +527,30 @@ export function GamePage({ connection, source }: GamePageProps) {
               <DialogTitle className="text-2xl">
                 {activeModal === "eliminated"
                   ? "You have been eliminated"
-                  : didWin
-                    ? "You won"
-                    : winnerId
-                      ? "You lost"
-                      : "Game over"}
+                  : didWin && isTeamResult
+                    ? "Your team won"
+                    : didWin
+                      ? "You won"
+                      : winnerTeamId && isTeamResult
+                        ? "Your team lost"
+                        : winnerTeamId
+                          ? "You lost"
+                          : "Game over"}
               </DialogTitle>
             </DialogHeader>
             <div className="mt-3 space-y-1 text-sm text-game-text-dim">
               {activeModal === "eliminated" ? null : (
                 <>
-                  {!didWin && winnerName ? <p>Winner: {winnerName}</p> : null}
-                  {!gameResult?.winnerTeamId ? (
-                    <p>No winner was reported.</p>
+                  {!didWin && isTeamResult && winnerTeamLabel ? (
+                    <p>
+                      Winners: {winnerTeamLabel},{" "}
+                      {winnerTeamMembers.join(" & ")}
+                    </p>
                   ) : null}
+                  {!didWin && !isTeamResult && winnerName ? (
+                    <p>Winner: {winnerName}</p>
+                  ) : null}
+                  {!winnerTeamId ? <p>No winner was reported.</p> : null}
                 </>
               )}
             </div>

--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -538,6 +538,9 @@ export function GamePage({ connection, source }: GamePageProps) {
                       {winnerTeamMembers.join(" & ")}
                     </p>
                   ) : null}
+                  {didWin && isTeamResult && winnerTeamLabel ? (
+                    <p>Team members: {winnerTeamMembers.join(" & ")}</p>
+                  ) : null}
                   {!didWin && !isTeamResult && winnerName ? (
                     <p>Winner: {winnerName}</p>
                   ) : null}

--- a/apps/client/src/features/game/pages/game-page.tsx
+++ b/apps/client/src/features/game/pages/game-page.tsx
@@ -30,6 +30,7 @@ import type { Ping } from "#/features/game/renderer/layers/ping";
 import { isCoordInBounds, isSameCoord } from "#/features/game/utils/coord";
 import type { MoveDirection } from "#/features/game/utils/move";
 import { getTargetCoord } from "#/features/game/utils/move";
+import { formatTeamLabel } from "#/features/match/utils/team-label";
 import { cn } from "#/lib/utils";
 
 export type GamePageSource =
@@ -57,16 +58,6 @@ interface PublicPlayerLike {
   id: string;
   teamId: string;
   displayName?: string;
-}
-
-function formatTeamLabel(teamId: string): string {
-  if (teamId.startsWith("team_")) {
-    const num = Number.parseInt(teamId.substring("team_".length), 10);
-    if (!Number.isNaN(num)) {
-      return `Team ${num + 1}`;
-    }
-  }
-  return `Team ${teamId}`;
 }
 
 function getTeamMembers(

--- a/apps/client/src/features/match/utils/scoreboard-adapter.ts
+++ b/apps/client/src/features/match/utils/scoreboard-adapter.ts
@@ -1,6 +1,8 @@
 import { GameMode } from "@generals-plus/engine";
 import type { BaseScoreboard } from "@generals-plus/shared-types";
 
+import { formatTeamLabel } from "#/features/match/utils/team-label";
+
 /**
  * Column metadata used by the match HUD scoreboard table.
  */
@@ -216,20 +218,6 @@ function createPlayerRows(scoreboard: BaseScoreboard): GameHudRow[] {
         Number(b.values.troops) - Number(a.values.troops) ||
         a.label.localeCompare(b.label),
     );
-}
-
-/**
- * Prettifies raw team identifiers (e.g. "team_0" -> "Team 1").
- */
-function formatTeamLabel(teamId: string): string {
-  if (teamId.startsWith("team_")) {
-    const numPart = teamId.substring("team_".length);
-    const num = Number.parseInt(numPart, 10);
-    if (!Number.isNaN(num)) {
-      return `Team ${num + 1}`;
-    }
-  }
-  return `Team ${teamId}`;
 }
 
 /**

--- a/apps/client/src/features/match/utils/team-label.ts
+++ b/apps/client/src/features/match/utils/team-label.ts
@@ -1,0 +1,12 @@
+/**
+ * Prettifies raw team identifiers (e.g. "team_0" -> "Team 1").
+ */
+export function formatTeamLabel(teamId: string): string {
+  if (teamId.startsWith("team_")) {
+    const num = Number.parseInt(teamId.substring("team_".length), 10);
+    if (!Number.isNaN(num)) {
+      return `Team ${num + 1}`;
+    }
+  }
+  return `Team ${teamId}`;
+}

--- a/apps/client/tests/features/game/pages/game-page.test.tsx
+++ b/apps/client/tests/features/game/pages/game-page.test.tsx
@@ -248,6 +248,104 @@ describe("GamePage", () => {
     expect(onReturn).toHaveBeenCalledTimes(1);
   });
 
+  it("shows winning team details for a lost team match", () => {
+    useGameRoomMock.mockReturnValue({
+      room: {
+        sessionId: "player-1",
+        onMessage: vi.fn().mockReturnValue(() => {}),
+      },
+      playerColors: new Map(),
+      playerNames: new Map([
+        ["player-2", "Rook"],
+        ["player-3", "Slate"],
+      ]),
+      currentPlayer: createPlayer({ teamId: "team_0" }),
+      renderGrid: createRenderGrid(2, 2),
+      moveQueue: [],
+      gameState: createGameState({ teamId: "team_0" }, [
+        {
+          id: "player-2",
+          teamId: "team_1",
+          displayName: "Rook",
+          color: 0xff6633,
+          status: PlayerStatus.ACTIVE,
+        },
+        {
+          id: "player-3",
+          teamId: "team_1",
+          displayName: "Slate",
+          color: 0x33cc99,
+          status: PlayerStatus.ACTIVE,
+        },
+      ]),
+      gameResult: {
+        mode: GameMode.CLASSIC,
+        winnerTeamId: "team_1",
+      },
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      error: null,
+      disconnectMessage: null,
+      isConnecting: false,
+    });
+
+    render(
+      <GamePage
+        connection={createConnection()}
+        source={{ type: "official", onReturn: vi.fn() }}
+      />,
+    );
+
+    expect(screen.getByText("Your team lost")).toBeTruthy();
+    expect(screen.getByText("Winners: Team 2, Rook & Slate")).toBeTruthy();
+    expect(screen.queryByText("Winner: Rook")).toBeNull();
+  });
+
+  it("uses team victory wording when the current player's team wins", () => {
+    useGameRoomMock.mockReturnValue({
+      room: {
+        sessionId: "player-1",
+        onMessage: vi.fn().mockReturnValue(() => {}),
+      },
+      playerColors: new Map(),
+      playerNames: new Map([
+        ["player-1", "Nova"],
+        ["player-4", "Mica"],
+      ]),
+      currentPlayer: createPlayer({ teamId: "team_0" }),
+      renderGrid: createRenderGrid(2, 2),
+      moveQueue: [],
+      gameState: createGameState({ teamId: "team_0" }, [
+        {
+          id: "player-4",
+          teamId: "team_0",
+          displayName: "Mica",
+          color: 0x44aaee,
+          status: PlayerStatus.ACTIVE,
+        },
+      ]),
+      gameResult: {
+        mode: GameMode.CLASSIC,
+        winnerTeamId: "team_0",
+      },
+      sendMove: sendMoveMock,
+      clearMoveQueue: vi.fn(),
+      error: null,
+      disconnectMessage: null,
+      isConnecting: false,
+    });
+
+    render(
+      <GamePage
+        connection={createConnection()}
+        source={{ type: "official", onReturn: vi.fn() }}
+      />,
+    );
+
+    expect(screen.getByText("Your team won")).toBeTruthy();
+    expect(screen.queryByText("You won")).toBeNull();
+  });
+
   it("offers spectator view after the current player is eliminated", () => {
     const onReturn = vi.fn();
 


### PR DESCRIPTION
Closes #126.

This pull request enhances the end-of-game messaging for team matches in the `GamePage` component, making the win/loss dialogs more accurate and informative for both solo and team games. It introduces helper functions to better format team labels and list team members, and updates the UI to distinguish between individual and team victories. Comprehensive tests have also been added to ensure correct behavior for various team scenarios.

**Improvements to team victory handling:**

- Added `formatTeamLabel` and `getTeamMembers` helper functions to generate user-friendly team labels and member lists for display in the UI. (`apps/client/src/features/game/pages/game-page.tsx`)
- Updated the logic in `GamePage` to detect team victories, display "Your team won"/"Your team lost" when appropriate, and show all winning team members and their team label. (`apps/client/src/features/game/pages/game-page.tsx`) [[1]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29L315-R355) [[2]](diffhunk://#diff-46202ac51fe9021fa33af02da3886176fba38e4ee056533ab9ed0b9a5a82fb29R530-R553)

**Testing:**

- Added tests to verify that the correct victory/defeat messages and winner details are shown for both team and individual games, including edge cases for team wins and losses. (`apps/client/tests/features/game/pages/game-page.test.tsx`)