### PR TITLE
feat(server): custom map

### DIFF
--- a/apps/client/src/components/ui/checkbox.tsx
+++ b/apps/client/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import { Check } from "lucide-react";
+import { Checkbox as CheckboxPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "#/lib/utils.ts";
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer group/checkbox relative flex size-4 shrink-0 rounded-none border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:bg-input/30 dark:data-checked:bg-primary dark:data-checked:text-primary-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex size-4 items-center justify-center text-current"
+      >
+        <Check className="size-3" strokeWidth={3} />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/apps/client/src/features/game/components/game-settings.tsx
+++ b/apps/client/src/features/game/components/game-settings.tsx
@@ -2,6 +2,7 @@ import { CollapseShape, GameMode, GridType } from "@generals-plus/engine";
 import type {
   ClassicSetupSettings,
   CollapseSetupSettings,
+  CustomMap,
   DemolitionSetupSettings,
   DominationSetupSettings,
   PayloadSetupSettings,
@@ -9,8 +10,9 @@ import type {
   SetupState,
   TurfWarSetupSettings,
 } from "@generals-plus/shared-types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { Button } from "#/components/ui/button";
 import { Input } from "#/components/ui/input";
 import { Label } from "#/components/ui/label";
 import {
@@ -22,6 +24,8 @@ import {
 } from "#/components/ui/select";
 import { Switch } from "#/components/ui/switch";
 import { GAME_MODE_OPTIONS } from "#/config/ui-constants";
+import { mapsApi } from "#/features/map-editor/api/maps-api";
+import { MapPickerDialog } from "#/features/map-editor/components/map-picker-dialog";
 import { cn } from "#/lib/utils";
 
 interface GameSettingsProps {
@@ -131,6 +135,31 @@ export function GameSettings({
       ? Math.ceil(currentSettings.maxPlayers / 2)
       : 1;
 
+  const isCustomMap = currentSettings.mapSource === "custom";
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [selectedMap, setSelectedMap] = useState<CustomMap | null>(null);
+
+  // Load the selected custom map details when customMapId changes
+  useEffect(() => {
+    if (!currentSettings.customMapId) {
+      setSelectedMap(null);
+      return;
+    }
+    if (selectedMap?.id === currentSettings.customMapId) return;
+    let cancelled = false;
+    mapsApi
+      .get(currentSettings.customMapId)
+      .then((map) => {
+        if (!cancelled) setSelectedMap(map);
+      })
+      .catch(() => {
+        if (!cancelled) setSelectedMap(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentSettings.customMapId, selectedMap?.id]);
+
   // Tracks the field currently being edited and its intermediate string value
   const [editing, setEditing] = useState<{
     key: NumberKeys;
@@ -178,32 +207,71 @@ export function GameSettings({
   }: {
     key: NumberKeys;
     label: string;
-  }) => (
-    <div key={key} className={fieldClassName}>
-      <Label htmlFor={key} className={labelClassName}>
-        {label}
-      </Label>
-      <Input
-        id={key}
-        type="number"
-        disabled={!isHost}
-        min={key === "playersPerTeam" ? demolitionPlayersPerTeamMin : undefined}
-        value={
-          editing?.key === key ? editing.value : round(currentSettings[key])
-        }
-        onFocus={() => handleFocus(key, currentSettings[key])}
-        onBlur={handleSubmit}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") handleSubmit();
-        }}
-        onChange={(e) => handleNumberChange(e.target.value)}
-        className={inputClassName}
-      />
-    </div>
-  );
+  }) => {
+    const isMapField =
+      key === "mapWidth" ||
+      key === "mapHeight" ||
+      key === "mapLeft" ||
+      key === "mapRight" ||
+      key === "mapLeftSlant" ||
+      key === "mapRightSlant" ||
+      key === "seed" ||
+      key === "mountainRate" ||
+      key === "cityRate" ||
+      key === "minGeneralDistanceFactor" ||
+      key === "generalInitialTroops" ||
+      key === "cityInitialTroops" ||
+      key === "bombSiteCount" ||
+      key === "flagCount" ||
+      key === "maxPlayers";
+    const disabled = !isHost || (isCustomMap && isMapField);
+    return (
+      <div key={key} className={fieldClassName}>
+        <Label htmlFor={key} className={labelClassName}>
+          {label}
+        </Label>
+        <Input
+          id={key}
+          type="number"
+          disabled={disabled}
+          min={
+            key === "playersPerTeam" ? demolitionPlayersPerTeamMin : undefined
+          }
+          value={
+            editing?.key === key ? editing.value : round(currentSettings[key])
+          }
+          onFocus={() => handleFocus(key, currentSettings[key])}
+          onBlur={handleSubmit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+          }}
+          onChange={(e) => handleNumberChange(e.target.value)}
+          className={inputClassName}
+        />
+      </div>
+    );
+  };
 
   return (
     <section aria-labelledby="game-settings-title" className="space-y-4">
+      <MapPickerDialog
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={(map) => {
+          // Pick a compatible mode if current one is unsupported
+          const modeOk = map.supportedModes.includes(currentSettings.gameMode);
+          const nextMode = modeOk
+            ? currentSettings.gameMode
+            : map.supportedModes[0];
+          onChangeSettings({
+            mapSource: "custom",
+            customMapId: map.id,
+            mapType: map.grid.gridType,
+            maxPlayers: map.maxPlayers,
+            ...(nextMode && !modeOk ? { gameMode: nextMode } : {}),
+          });
+        }}
+      />
       <div className="flex items-baseline justify-between gap-3">
         <h2 id="game-settings-title" className="text-xl font-semibold">
           Game Settings
@@ -216,6 +284,42 @@ export function GameSettings({
       </div>
 
       <div className="grid gap-3 text-left sm:grid-cols-2 lg:grid-cols-3">
+        <div className={cn(fieldClassName, "sm:col-span-2 lg:col-span-3")}>
+          <Label className={labelClassName}>Map Source</Label>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant={isCustomMap ? "outline" : "default"}
+              size="sm"
+              disabled={!isHost}
+              onClick={() =>
+                onChangeSettings({ mapSource: "generated", customMapId: "" })
+              }
+            >
+              Generated
+            </Button>
+            <Button
+              type="button"
+              variant={isCustomMap ? "default" : "outline"}
+              size="sm"
+              disabled={!isHost}
+              onClick={() => setPickerOpen(true)}
+            >
+              {isCustomMap && selectedMap
+                ? `Custom: ${selectedMap.name}`
+                : "Choose Custom..."}
+            </Button>
+            {isCustomMap && selectedMap && (
+              <span className="text-xs text-game-text-dim">
+                by {selectedMap.authorName} ·{" "}
+                {selectedMap.minPlayers === selectedMap.maxPlayers
+                  ? `${selectedMap.minPlayers} players`
+                  : `${selectedMap.minPlayers}-${selectedMap.maxPlayers} players`}
+              </span>
+            )}
+          </div>
+        </div>
+
         <div className={fieldClassName}>
           <Label id="game-mode-label" className={labelClassName}>
             Game Mode
@@ -236,16 +340,23 @@ export function GameSettings({
               <SelectValue />
             </SelectTrigger>
             <SelectContent className="border border-game-border bg-game-surface text-game-text">
-              {GAME_MODE_OPTIONS.map((mode) => (
-                <SelectItem
-                  key={mode.id}
-                  value={mode.id}
-                  disabled={!mode.isEnabled}
-                >
-                  {mode.label}
-                  {mode.isEnabled ? "" : " (coming soon)"}
-                </SelectItem>
-              ))}
+              {GAME_MODE_OPTIONS.map((mode) => {
+                const supportedByMap =
+                  !isCustomMap ||
+                  !selectedMap ||
+                  selectedMap.supportedModes.includes(mode.id);
+                return (
+                  <SelectItem
+                    key={mode.id}
+                    value={mode.id}
+                    disabled={!mode.isEnabled || !supportedByMap}
+                  >
+                    {mode.label}
+                    {mode.isEnabled ? "" : " (coming soon)"}
+                    {!supportedByMap ? " (not supported by map)" : ""}
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
         </div>
@@ -311,7 +422,7 @@ export function GameSettings({
             Map Type
           </Label>
           <Select
-            disabled={!isHost}
+            disabled={!isHost || isCustomMap}
             value={currentSettings.mapType ?? GridType.SQUARE}
             onValueChange={(val) => {
               const type = MAP_TYPE_OPTIONS.find((o) => o.id === val)?.id;

--- a/apps/client/src/features/lobby/pages/lobby-page.tsx
+++ b/apps/client/src/features/lobby/pages/lobby-page.tsx
@@ -4,7 +4,7 @@ import {
   CUSTOM_ROOM_KEY_MIN_LENGTH,
   isValidCustomRoomKeyLength,
 } from "@generals-plus/shared-types";
-import { LogOut, Play, Plus, User } from "lucide-react";
+import { LogOut, Map as MapIcon, Play, Plus, User } from "lucide-react";
 import { useState } from "react";
 import { Link, useNavigate } from "react-router";
 
@@ -153,6 +153,12 @@ export function LobbyPage({ onQueue }: { onQueue: (mode: GameMode) => void }) {
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-2">
+              <Button asChild variant="ghost">
+                <Link to="/maps">
+                  <MapIcon className="size-4" />
+                  Maps
+                </Link>
+              </Button>
               <Button asChild variant="ghost">
                 <Link to="/profile">
                   <User className="size-4" />

--- a/apps/client/src/features/map-editor/api/maps-api.ts
+++ b/apps/client/src/features/map-editor/api/maps-api.ts
@@ -1,0 +1,105 @@
+import type {
+  CreateCustomMapRequest,
+  CustomMap,
+  CustomMapListResponse,
+  UpdateCustomMapRequest,
+} from "@generals-plus/shared-types";
+
+import { resolveColyseusEndpoint } from "#/infra/colyseus/connection";
+import { networkProvider } from "#/infra/network/provider";
+
+function getHttpEndpoint(): string {
+  return resolveColyseusEndpoint().replace(/^ws/i, "http");
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = networkProvider.getAuthToken();
+  const response = await fetch(new URL(path, getHttpEndpoint()), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(init.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    let message = response.statusText;
+    let details: unknown;
+    try {
+      const payload = (await response.json()) as {
+        error?: string;
+        details?: unknown;
+      };
+      message = payload.error ?? message;
+      details = payload.details;
+    } catch {
+      // Ignore non-JSON error bodies
+    }
+    const err = new Error(message) as Error & {
+      status: number;
+      details?: unknown;
+    };
+    err.status = response.status;
+    err.details = details;
+    throw err;
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return (await response.json()) as T;
+}
+
+export interface ListMapsParams {
+  page?: number;
+  limit?: number;
+  mode?: string;
+  sort?: "plays" | "likes" | "date";
+}
+
+export const mapsApi = {
+  async list(params: ListMapsParams = {}): Promise<CustomMapListResponse> {
+    const search = new URLSearchParams();
+    if (params.page) search.set("page", String(params.page));
+    if (params.limit) search.set("limit", String(params.limit));
+    if (params.mode) search.set("mode", params.mode);
+    if (params.sort) search.set("sort", params.sort);
+    const qs = search.toString();
+    return request<CustomMapListResponse>(`/api/maps${qs ? `?${qs}` : ""}`);
+  },
+
+  async get(id: string): Promise<CustomMap> {
+    return request<CustomMap>(`/api/maps/${encodeURIComponent(id)}`);
+  },
+
+  async create(payload: CreateCustomMapRequest): Promise<CustomMap> {
+    return request<CustomMap>("/api/maps", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  },
+
+  async update(
+    id: string,
+    payload: UpdateCustomMapRequest,
+  ): Promise<CustomMap> {
+    return request<CustomMap>(`/api/maps/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+  },
+
+  async remove(id: string): Promise<void> {
+    await request<void>(`/api/maps/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+  },
+
+  async toggleLike(id: string): Promise<{ result: "liked" | "unliked" }> {
+    return request<{ result: "liked" | "unliked" }>(
+      `/api/maps/${encodeURIComponent(id)}/like`,
+      { method: "POST" },
+    );
+  },
+};

--- a/apps/client/src/features/map-editor/components/editor-canvas.tsx
+++ b/apps/client/src/features/map-editor/components/editor-canvas.tsx
@@ -1,15 +1,17 @@
 import type { ICoordinate } from "@generals-plus/engine";
-import {
-  GridType,
-  HexGrid2D,
-  Terrain,
-  Visibility,
-} from "@generals-plus/engine";
+import { GridType, Visibility } from "@generals-plus/engine";
 import type { CellTemplate, SpawnPoint } from "@generals-plus/shared-types";
 import { Application, extend } from "@pixi/react";
 import type { FederatedPointerEvent } from "pixi.js";
-import { Assets, Container, Graphics, Rectangle, Text } from "pixi.js";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Assets,
+  Container,
+  Graphics,
+  Rectangle,
+  Text,
+  TextStyle,
+} from "pixi.js";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   cityIcon,
@@ -19,18 +21,29 @@ import {
   mountainIcon,
   swampIcon,
 } from "#/features/game/assets";
+import { GridLayer } from "#/features/game/renderer/layers/grid";
+import { IconLayer } from "#/features/game/renderer/layers/icon";
+import { PayloadLayer } from "#/features/game/renderer/layers/payload";
+import { SiteLabelLayer } from "#/features/game/renderer/layers/site-label";
+import { TroopLayer } from "#/features/game/renderer/layers/troop";
 import { RenderConfig } from "#/features/game/renderer/render-config";
 import type { RenderGrid } from "#/features/game/renderer/render-grid";
 import {
   HexRenderGrid,
   SquareRenderGrid,
 } from "#/features/game/renderer/render-grid";
-import { TerrainTheme } from "#/features/game/renderer/theme";
 import { Viewport } from "#/features/game/renderer/viewport";
-import { drawCell } from "#/features/game/utils/renderer";
 import { useEditorStore } from "#/features/map-editor/store/editor-store";
 
 extend({ Container, Graphics, Text });
+
+const SPAWN_TEXT_STYLE = new TextStyle({
+  fontFamily: "Oxanium Variable, sans-serif",
+  fontSize: 22,
+  fill: 0xffffff,
+  stroke: { color: 0x111111, width: 4 },
+  fontWeight: "900",
+});
 
 function buildRenderGrid(
   gridType: GridType,
@@ -93,18 +106,66 @@ interface EditorCanvasProps {
   playerColorByTeam: Map<string, number>;
 }
 
-function EditorScene({
+interface EditorSpawnLayerProps {
+  grid: RenderGrid;
+  spawns: SpawnPoint[];
+}
+
+// Memoized to prevent Pixi display object reconciliation flickering on mouse move
+const EditorSpawnLayer = memo(function EditorSpawnLayer({
+  grid,
+  spawns,
+}: EditorSpawnLayerProps) {
+  const drawSpawns = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      // Draw small ring for each spawn
+      for (const s of spawns) {
+        const c = grid.toCartesian({ x: s.x, y: s.y });
+        const x = c.x * RenderConfig.cellStride;
+        const y = c.y * RenderConfig.cellStride;
+        g.circle(x, y, RenderConfig.cellStride * 0.4);
+        g.stroke({ width: 3, color: 0xffffff, alpha: 0.85 });
+      }
+    },
+    [grid, spawns],
+  );
+
+  return (
+    <pixiContainer>
+      <pixiGraphics draw={drawSpawns} />
+      {spawns.map((s) => {
+        const c = grid.toCartesian({ x: s.x, y: s.y });
+        const x = c.x * RenderConfig.cellStride;
+        const y =
+          c.y * RenderConfig.cellStride + RenderConfig.cellStride * 0.45;
+        const text = `${s.teamId}/${s.slot}`;
+        return (
+          <pixiText
+            key={`spawn-label-${s.x},${s.y}`}
+            text={text}
+            anchor={0.5}
+            x={x}
+            y={y}
+            style={SPAWN_TEXT_STYLE}
+          />
+        );
+      })}
+    </pixiContainer>
+  );
+});
+
+// Memoized to completely isolate Pixi sublayers from parent re-renders when mouse moves/drags
+const EditorScene = memo(function EditorScene({
   grid,
   spawns,
   track,
-  cells,
   playerColorByTeam,
   onCellClick,
 }: {
   grid: RenderGrid;
   spawns: SpawnPoint[];
   track: ICoordinate[];
-  cells: CellTemplate[][];
   playerColorByTeam: Map<string, number>;
   onCellClick: (coord: ICoordinate) => void;
 }) {
@@ -120,66 +181,6 @@ function EditorScene({
     return new Rectangle(-10000, -10000, 20000, 20000);
   }, [grid]);
 
-  const drawBase = useCallback(
-    (g: Graphics) => {
-      g.clear();
-      grid.forEach((cell, coord) => {
-        drawCell(g, grid, coord);
-        const theme = TerrainTheme[cell.terrain];
-        let color = theme?.color ?? 0xffffff;
-        if (cell.ownerIndex) {
-          color = playerColorByTeam.get(cell.ownerIndex) ?? color;
-        }
-        g.stroke({
-          width: RenderConfig.cellStroke,
-          color: RenderConfig.background,
-        });
-        g.fill(color);
-      });
-    },
-    [grid, playerColorByTeam],
-  );
-
-  const drawTrack = useCallback(
-    (g: Graphics) => {
-      g.clear();
-      if (track.length === 0) return;
-      for (let i = 0; i < track.length; i++) {
-        const p = track[i];
-        const c = grid.toCartesian(p);
-        const x = c.x * RenderConfig.cellStride;
-        const y = c.y * RenderConfig.cellStride;
-        g.circle(x, y, RenderConfig.cellStride * 0.15);
-        g.fill({ color: 0x3498db, alpha: 0.85 });
-        if (i > 0) {
-          const prev = grid.toCartesian(track[i - 1]);
-          g.moveTo(
-            prev.x * RenderConfig.cellStride,
-            prev.y * RenderConfig.cellStride,
-          );
-          g.lineTo(x, y);
-          g.stroke({ width: 8, color: 0x3498db, alpha: 0.5 });
-        }
-      }
-    },
-    [grid, track],
-  );
-
-  const drawSpawnLabels = useCallback(
-    (g: Graphics) => {
-      g.clear();
-      // Draw small ring for each spawn
-      for (const s of spawns) {
-        const c = grid.toCartesian({ x: s.x, y: s.y });
-        const x = c.x * RenderConfig.cellStride;
-        const y = c.y * RenderConfig.cellStride;
-        g.circle(x, y, RenderConfig.cellStride * 0.4);
-        g.stroke({ width: 3, color: 0xffffff, alpha: 0.85 });
-      }
-    },
-    [grid, spawns],
-  );
-
   const onPointerDown = useCallback(
     (e: FederatedPointerEvent) => {
       const localPos = e.currentTarget.toLocal(e.global);
@@ -192,44 +193,8 @@ function EditorScene({
     [grid, onCellClick],
   );
 
-  // Render bombsite labels and general icons via Text elements
-  const labels = useMemo(() => {
-    const items: {
-      x: number;
-      y: number;
-      text: string;
-      kind: "bomb" | "spawn";
-    }[] = [];
-    for (let y = 0; y < cells.length; y++) {
-      for (let x = 0; x < cells[y].length; x++) {
-        const cell = cells[y][x];
-        const offset =
-          grid.gridType === GridType.HEX
-            ? HexGrid2D.getMinX(y, (grid as HexRenderGrid).bounds.left)
-            : 0;
-        const realX = offset + x;
-        if (cell.terrain === Terrain.BOMB_SITE && cell.siteIndex !== null) {
-          const c = grid.toCartesian({ x: realX, y });
-          items.push({
-            x: c.x * RenderConfig.cellStride,
-            y: c.y * RenderConfig.cellStride,
-            text: String.fromCharCode(65 + cell.siteIndex),
-            kind: "bomb",
-          });
-        }
-      }
-    }
-    for (const s of spawns) {
-      const c = grid.toCartesian({ x: s.x, y: s.y });
-      items.push({
-        x: c.x * RenderConfig.cellStride,
-        y: c.y * RenderConfig.cellStride + RenderConfig.cellStride * 0.45,
-        text: `${s.teamId}/${s.slot}`,
-        kind: "spawn",
-      });
-    }
-    return items;
-  }, [cells, spawns, grid]);
+  const payloadTrackX = useMemo(() => track.map((t) => t.x), [track]);
+  const payloadTrackY = useMemo(() => track.map((t) => t.y), [track]);
 
   return (
     <pixiContainer
@@ -237,28 +202,34 @@ function EditorScene({
       hitArea={hitArea}
       onPointerDown={onPointerDown}
     >
-      <pixiGraphics draw={drawBase} />
-      <pixiGraphics draw={drawTrack} />
-      <pixiGraphics draw={drawSpawnLabels} />
-      {labels.map((l) => (
-        <pixiText
-          key={`${l.kind}-${l.x.toFixed(1)}-${l.y.toFixed(1)}-${l.text}`}
-          text={l.text}
-          x={l.x}
-          y={l.y}
-          anchor={0.5}
-          style={{
-            fontFamily: "Oxanium Variable, sans-serif",
-            fontSize: l.kind === "bomb" ? 60 : 22,
-            fill: 0xffffff,
-            stroke: { color: 0x111111, width: 4 },
-            fontWeight: "900",
-          }}
+      {/* 1. Base cell rendering with correct player colors */}
+      <GridLayer tick={0} grid={grid} playerColors={playerColorByTeam} />
+
+      {/* 2. Terrain icons (Mountain, Swamp, Desert, City, Flag, Crown/General) */}
+      <IconLayer tick={0} grid={grid} />
+
+      {/* 3. Payload railroad route track */}
+      {payloadTrackX.length > 0 && (
+        <PayloadLayer
+          grid={grid}
+          payloadTrackX={payloadTrackX}
+          payloadTrackY={payloadTrackY}
+          cartIndex={-1}
+          cartSize={0}
         />
-      ))}
+      )}
+
+      {/* 4. Demolition bomb site labels (A, B, C...) */}
+      <SiteLabelLayer grid={grid} />
+
+      {/* 5. City and cell troop numbers */}
+      <TroopLayer tick={0} grid={grid} splitMoveSelection={null} />
+
+      {/* 6. Editor-specific player general spawn points & rings */}
+      <EditorSpawnLayer grid={grid} spawns={spawns} />
     </pixiContainer>
   );
-}
+});
 
 export function EditorCanvas({ playerColorByTeam }: EditorCanvasProps) {
   const gridType = useEditorStore((s) => s.gridType);
@@ -334,7 +305,6 @@ export function EditorCanvas({ playerColorByTeam }: EditorCanvasProps) {
           <Viewport worldBounds={worldBounds}>
             <EditorScene
               grid={grid}
-              cells={cells}
               spawns={spawns}
               track={track}
               playerColorByTeam={playerColorByTeam}
@@ -346,3 +316,6 @@ export function EditorCanvas({ playerColorByTeam }: EditorCanvasProps) {
     </div>
   );
 }
+
+export function default_canvas_export() {}
+export default EditorCanvas;

--- a/apps/client/src/features/map-editor/components/editor-canvas.tsx
+++ b/apps/client/src/features/map-editor/components/editor-canvas.tsx
@@ -1,0 +1,348 @@
+import type { ICoordinate } from "@generals-plus/engine";
+import {
+  GridType,
+  HexGrid2D,
+  Terrain,
+  Visibility,
+} from "@generals-plus/engine";
+import type { CellTemplate, SpawnPoint } from "@generals-plus/shared-types";
+import { Application, extend } from "@pixi/react";
+import type { FederatedPointerEvent } from "pixi.js";
+import { Assets, Container, Graphics, Rectangle, Text } from "pixi.js";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  cityIcon,
+  crownIcon,
+  desertIcon,
+  flagIcon,
+  mountainIcon,
+  swampIcon,
+} from "#/features/game/assets";
+import { RenderConfig } from "#/features/game/renderer/render-config";
+import type { RenderGrid } from "#/features/game/renderer/render-grid";
+import {
+  HexRenderGrid,
+  SquareRenderGrid,
+} from "#/features/game/renderer/render-grid";
+import { TerrainTheme } from "#/features/game/renderer/theme";
+import { Viewport } from "#/features/game/renderer/viewport";
+import { drawCell } from "#/features/game/utils/renderer";
+import { useEditorStore } from "#/features/map-editor/store/editor-store";
+
+extend({ Container, Graphics, Text });
+
+function buildRenderGrid(
+  gridType: GridType,
+  bounds: { width?: number; height?: number } & {
+    left?: number;
+    right?: number;
+    leftSlant?: number;
+    rightSlant?: number;
+  },
+  cells: CellTemplate[][],
+  spawns: SpawnPoint[],
+  _playerColorByTeam: Map<string, number>,
+): RenderGrid {
+  const spawnByCoord = new Map<string, SpawnPoint>();
+  for (const s of spawns) {
+    spawnByCoord.set(`${s.x},${s.y}`, s);
+  }
+
+  const buildCell = (cellTpl: CellTemplate, coord: ICoordinate) => {
+    const spawn = spawnByCoord.get(`${coord.x},${coord.y}`);
+    const ownerIndex = spawn ? spawn.teamId : null;
+    return {
+      coordinate: coord,
+      visibility: Visibility.VISIBLE,
+      terrain: cellTpl.terrain,
+      troopCount: cellTpl.troopCount,
+      ownerIndex,
+      siteIndex: cellTpl.siteIndex,
+      item: null,
+    };
+  };
+
+  if (gridType === GridType.SQUARE) {
+    const width = bounds.width ?? 0;
+    const height = bounds.height ?? 0;
+    return SquareRenderGrid.fromArray<
+      CellTemplate,
+      ReturnType<typeof buildCell>
+    >(width, height, cells.flat(), buildCell);
+  }
+
+  const { left, right, leftSlant, rightSlant } = bounds as {
+    left: number;
+    right: number;
+    leftSlant: number;
+    rightSlant: number;
+  };
+  return HexRenderGrid.fromArray<CellTemplate, ReturnType<typeof buildCell>>(
+    left,
+    right,
+    leftSlant,
+    rightSlant,
+    cells.flat(),
+    buildCell,
+  );
+}
+
+interface EditorCanvasProps {
+  /** Player palette: teamId → color (used to tint generals on the canvas) */
+  playerColorByTeam: Map<string, number>;
+}
+
+function EditorScene({
+  grid,
+  spawns,
+  track,
+  cells,
+  playerColorByTeam,
+  onCellClick,
+}: {
+  grid: RenderGrid;
+  spawns: SpawnPoint[];
+  track: ICoordinate[];
+  cells: CellTemplate[][];
+  playerColorByTeam: Map<string, number>;
+  onCellClick: (coord: ICoordinate) => void;
+}) {
+  const hitArea = useMemo(() => {
+    if (grid.gridType === GridType.SQUARE) {
+      return new Rectangle(
+        -0.5 * RenderConfig.cellStride,
+        -0.5 * RenderConfig.cellStride,
+        (grid.bounds.width + 0.5) * RenderConfig.cellStride,
+        (grid.bounds.height + 0.5) * RenderConfig.cellStride,
+      );
+    }
+    return new Rectangle(-10000, -10000, 20000, 20000);
+  }, [grid]);
+
+  const drawBase = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      grid.forEach((cell, coord) => {
+        drawCell(g, grid, coord);
+        const theme = TerrainTheme[cell.terrain];
+        let color = theme?.color ?? 0xffffff;
+        if (cell.ownerIndex) {
+          color = playerColorByTeam.get(cell.ownerIndex) ?? color;
+        }
+        g.stroke({
+          width: RenderConfig.cellStroke,
+          color: RenderConfig.background,
+        });
+        g.fill(color);
+      });
+    },
+    [grid, playerColorByTeam],
+  );
+
+  const drawTrack = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      if (track.length === 0) return;
+      for (let i = 0; i < track.length; i++) {
+        const p = track[i];
+        const c = grid.toCartesian(p);
+        const x = c.x * RenderConfig.cellStride;
+        const y = c.y * RenderConfig.cellStride;
+        g.circle(x, y, RenderConfig.cellStride * 0.15);
+        g.fill({ color: 0x3498db, alpha: 0.85 });
+        if (i > 0) {
+          const prev = grid.toCartesian(track[i - 1]);
+          g.moveTo(
+            prev.x * RenderConfig.cellStride,
+            prev.y * RenderConfig.cellStride,
+          );
+          g.lineTo(x, y);
+          g.stroke({ width: 8, color: 0x3498db, alpha: 0.5 });
+        }
+      }
+    },
+    [grid, track],
+  );
+
+  const drawSpawnLabels = useCallback(
+    (g: Graphics) => {
+      g.clear();
+      // Draw small ring for each spawn
+      for (const s of spawns) {
+        const c = grid.toCartesian({ x: s.x, y: s.y });
+        const x = c.x * RenderConfig.cellStride;
+        const y = c.y * RenderConfig.cellStride;
+        g.circle(x, y, RenderConfig.cellStride * 0.4);
+        g.stroke({ width: 3, color: 0xffffff, alpha: 0.85 });
+      }
+    },
+    [grid, spawns],
+  );
+
+  const onPointerDown = useCallback(
+    (e: FederatedPointerEvent) => {
+      const localPos = e.currentTarget.toLocal(e.global);
+      const coord = grid.fromCartesian({
+        x: localPos.x / RenderConfig.cellStride,
+        y: localPos.y / RenderConfig.cellStride,
+      });
+      if (coord) onCellClick(coord);
+    },
+    [grid, onCellClick],
+  );
+
+  // Render bombsite labels and general icons via Text elements
+  const labels = useMemo(() => {
+    const items: {
+      x: number;
+      y: number;
+      text: string;
+      kind: "bomb" | "spawn";
+    }[] = [];
+    for (let y = 0; y < cells.length; y++) {
+      for (let x = 0; x < cells[y].length; x++) {
+        const cell = cells[y][x];
+        const offset =
+          grid.gridType === GridType.HEX
+            ? HexGrid2D.getMinX(y, (grid as HexRenderGrid).bounds.left)
+            : 0;
+        const realX = offset + x;
+        if (cell.terrain === Terrain.BOMB_SITE && cell.siteIndex !== null) {
+          const c = grid.toCartesian({ x: realX, y });
+          items.push({
+            x: c.x * RenderConfig.cellStride,
+            y: c.y * RenderConfig.cellStride,
+            text: String.fromCharCode(65 + cell.siteIndex),
+            kind: "bomb",
+          });
+        }
+      }
+    }
+    for (const s of spawns) {
+      const c = grid.toCartesian({ x: s.x, y: s.y });
+      items.push({
+        x: c.x * RenderConfig.cellStride,
+        y: c.y * RenderConfig.cellStride + RenderConfig.cellStride * 0.45,
+        text: `${s.teamId}/${s.slot}`,
+        kind: "spawn",
+      });
+    }
+    return items;
+  }, [cells, spawns, grid]);
+
+  return (
+    <pixiContainer
+      eventMode="static"
+      hitArea={hitArea}
+      onPointerDown={onPointerDown}
+    >
+      <pixiGraphics draw={drawBase} />
+      <pixiGraphics draw={drawTrack} />
+      <pixiGraphics draw={drawSpawnLabels} />
+      {labels.map((l) => (
+        <pixiText
+          key={`${l.kind}-${l.x.toFixed(1)}-${l.y.toFixed(1)}-${l.text}`}
+          text={l.text}
+          x={l.x}
+          y={l.y}
+          anchor={0.5}
+          style={{
+            fontFamily: "Oxanium Variable, sans-serif",
+            fontSize: l.kind === "bomb" ? 60 : 22,
+            fill: 0xffffff,
+            stroke: { color: 0x111111, width: 4 },
+            fontWeight: "900",
+          }}
+        />
+      ))}
+    </pixiContainer>
+  );
+}
+
+export function EditorCanvas({ playerColorByTeam }: EditorCanvasProps) {
+  const gridType = useEditorStore((s) => s.gridType);
+  const bounds = useEditorStore((s) => s.bounds);
+  const cells = useEditorStore((s) => s.cells);
+  const spawns = useEditorStore((s) => s.spawns);
+  const track = useEditorStore((s) => s.track);
+  const paintCell = useEditorStore((s) => s.paintCell);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const grid = useMemo(
+    () => buildRenderGrid(gridType, bounds, cells, spawns, playerColorByTeam),
+    [gridType, bounds, cells, spawns, playerColorByTeam],
+  );
+
+  const worldBounds = useMemo(() => {
+    if (gridType === GridType.SQUARE) {
+      const { width, height } = bounds as { width: number; height: number };
+      return {
+        left: -0.5 * RenderConfig.cellStride,
+        right: (width - 0.5) * RenderConfig.cellStride,
+        top: -0.5 * RenderConfig.cellStride,
+        bottom: (height - 0.5) * RenderConfig.cellStride,
+      };
+    }
+    const b = bounds as {
+      left: number;
+      right: number;
+      leftSlant: number;
+      rightSlant: number;
+    };
+    return {
+      left: -(b.left - 1 / 3) * RenderConfig.cellStride,
+      right: (b.right - 1 / 3) * RenderConfig.cellStride,
+      top: (-Math.sqrt(3) * RenderConfig.cellStride) / 3,
+      bottom:
+        (Math.max(b.leftSlant, b.rightSlant) / 1.5 - 1 / 3) *
+        Math.sqrt(3) *
+        RenderConfig.cellStride,
+    };
+  }, [gridType, bounds]);
+
+  useEffect(() => {
+    Assets.load([
+      cityIcon,
+      crownIcon,
+      desertIcon,
+      flagIcon,
+      mountainIcon,
+      swampIcon,
+    ])
+      .then(() => setIsReady(true))
+      .catch(() => setIsReady(true));
+  }, []);
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      {!isReady ? (
+        <div className="grid h-full place-items-center text-sm text-game-text-dim">
+          Loading editor
+        </div>
+      ) : (
+        <Application
+          resizeTo={containerRef}
+          className="h-full w-full"
+          backgroundColor={RenderConfig.background}
+          antialias={true}
+          autoDensity={true}
+          resolution={window.devicePixelRatio}
+        >
+          <Viewport worldBounds={worldBounds}>
+            <EditorScene
+              grid={grid}
+              cells={cells}
+              spawns={spawns}
+              track={track}
+              playerColorByTeam={playerColorByTeam}
+              onCellClick={paintCell}
+            />
+          </Viewport>
+        </Application>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/features/map-editor/components/editor-canvas.tsx
+++ b/apps/client/src/features/map-editor/components/editor-canvas.tsx
@@ -231,7 +231,9 @@ const EditorScene = memo(function EditorScene({
   );
 });
 
-export function EditorCanvas({ playerColorByTeam }: EditorCanvasProps) {
+export const EditorCanvas = memo(function EditorCanvas({
+  playerColorByTeam,
+}: EditorCanvasProps) {
   const gridType = useEditorStore((s) => s.gridType);
   const bounds = useEditorStore((s) => s.bounds);
   const cells = useEditorStore((s) => s.cells);
@@ -288,7 +290,7 @@ export function EditorCanvas({ playerColorByTeam }: EditorCanvasProps) {
   }, []);
 
   return (
-    <div ref={containerRef} className="h-full w-full">
+    <div ref={containerRef} className="h-full w-full overflow-hidden">
       {!isReady ? (
         <div className="grid h-full place-items-center text-sm text-game-text-dim">
           Loading editor
@@ -315,6 +317,6 @@ export function EditorCanvas({ playerColorByTeam }: EditorCanvasProps) {
       )}
     </div>
   );
-}
+});
 
 export default EditorCanvas;

--- a/apps/client/src/features/map-editor/components/editor-canvas.tsx
+++ b/apps/client/src/features/map-editor/components/editor-canvas.tsx
@@ -317,5 +317,4 @@ export function EditorCanvas({ playerColorByTeam }: EditorCanvasProps) {
   );
 }
 
-export function default_canvas_export() {}
 export default EditorCanvas;

--- a/apps/client/src/features/map-editor/components/map-metadata-panel.tsx
+++ b/apps/client/src/features/map-editor/components/map-metadata-panel.tsx
@@ -1,0 +1,162 @@
+import { GridType } from "@generals-plus/engine";
+
+import { Input } from "#/components/ui/input";
+import { Label } from "#/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#/components/ui/select";
+import { GAME_MODE_OPTIONS } from "#/config/ui-constants";
+import { useEditorStore } from "#/features/map-editor/store/editor-store";
+
+export function MapMetadataPanel() {
+  const name = useEditorStore((s) => s.name);
+  const description = useEditorStore((s) => s.description);
+  const setName = useEditorStore((s) => s.setName);
+  const setDescription = useEditorStore((s) => s.setDescription);
+  const gridType = useEditorStore((s) => s.gridType);
+  const bounds = useEditorStore((s) => s.bounds);
+  const setGridType = useEditorStore((s) => s.setGridType);
+  const setSquareBounds = useEditorStore((s) => s.setSquareBounds);
+  const setHexBounds = useEditorStore((s) => s.setHexBounds);
+  const supportedModes = useEditorStore((s) => s.supportedModes);
+  const setSupportedModes = useEditorStore((s) => s.setSupportedModes);
+
+  return (
+    <div className="grid gap-3 p-3">
+      <div>
+        <Label className="text-xs text-game-text-dim">Name</Label>
+        <Input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="h-8 border-game-border bg-game-bg text-sm text-game-text"
+        />
+      </div>
+
+      <div>
+        <Label className="text-xs text-game-text-dim">Description</Label>
+        <Input
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className="h-8 border-game-border bg-game-bg text-sm text-game-text"
+        />
+      </div>
+
+      <div>
+        <Label className="text-xs text-game-text-dim">Grid Type</Label>
+        <Select
+          value={gridType}
+          onValueChange={(v) => setGridType(v as GridType)}
+        >
+          <SelectTrigger
+            size="sm"
+            className="h-8 border-game-border bg-game-bg px-2 text-xs text-game-text"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent className="border-game-border bg-game-surface text-game-text">
+            <SelectItem value={GridType.SQUARE}>Square</SelectItem>
+            <SelectItem value={GridType.HEX}>Hex</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {gridType === GridType.SQUARE ? (
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <Label className="text-xs text-game-text-dim">Width</Label>
+            <Input
+              type="number"
+              min={5}
+              max={100}
+              value={(bounds as { width: number }).width}
+              onChange={(e) =>
+                setSquareBounds({
+                  width: Math.max(5, Math.min(100, Number(e.target.value))),
+                  height: (bounds as { height: number }).height,
+                })
+              }
+              className="h-8 border-game-border bg-game-bg text-sm text-game-text"
+            />
+          </div>
+          <div>
+            <Label className="text-xs text-game-text-dim">Height</Label>
+            <Input
+              type="number"
+              min={5}
+              max={100}
+              value={(bounds as { height: number }).height}
+              onChange={(e) =>
+                setSquareBounds({
+                  width: (bounds as { width: number }).width,
+                  height: Math.max(5, Math.min(100, Number(e.target.value))),
+                })
+              }
+              className="h-8 border-game-border bg-game-bg text-sm text-game-text"
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-2">
+          {(["left", "right", "leftSlant", "rightSlant"] as const).map(
+            (key) => (
+              <div key={key}>
+                <Label className="text-xs text-game-text-dim">{key}</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={(bounds as unknown as Record<string, number>)[key]}
+                  onChange={(e) =>
+                    setHexBounds({
+                      ...(bounds as {
+                        left: number;
+                        right: number;
+                        leftSlant: number;
+                        rightSlant: number;
+                      }),
+                      [key]: Math.max(1, Number(e.target.value)),
+                    })
+                  }
+                  className="h-8 border-game-border bg-game-bg text-sm text-game-text"
+                />
+              </div>
+            ),
+          )}
+        </div>
+      )}
+
+      <div>
+        <Label className="text-xs text-game-text-dim">Supported Modes</Label>
+        <div className="mt-1 grid grid-cols-2 gap-1.5">
+          {GAME_MODE_OPTIONS.map((mode) => {
+            const active = supportedModes.includes(mode.id);
+            return (
+              <label
+                key={mode.id}
+                className="flex cursor-pointer items-center gap-2 border border-game-border bg-game-bg px-2 py-1 text-xs text-game-text"
+              >
+                <input
+                  type="checkbox"
+                  checked={active}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setSupportedModes([...supportedModes, mode.id]);
+                    } else {
+                      setSupportedModes(
+                        supportedModes.filter((m) => m !== mode.id),
+                      );
+                    }
+                  }}
+                />
+                {mode.label}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/client/src/features/map-editor/components/map-metadata-panel.tsx
+++ b/apps/client/src/features/map-editor/components/map-metadata-panel.tsx
@@ -1,5 +1,6 @@
 import { GridType } from "@generals-plus/engine";
 
+import { Checkbox } from "#/components/ui/checkbox";
 import { Input } from "#/components/ui/input";
 import { Label } from "#/components/ui/label";
 import {
@@ -136,13 +137,14 @@ export function MapMetadataPanel() {
             return (
               <label
                 key={mode.id}
-                className="flex cursor-pointer items-center gap-2 border border-game-border bg-game-bg px-2 py-1 text-xs text-game-text"
+                htmlFor={`mode-chk-${mode.id}`}
+                className="flex cursor-pointer items-center gap-2 border border-game-border bg-game-bg px-2 py-1.5 text-xs text-game-text transition-colors hover:bg-game-surface"
               >
-                <input
-                  type="checkbox"
+                <Checkbox
+                  id={`mode-chk-${mode.id}`}
                   checked={active}
-                  onChange={(e) => {
-                    if (e.target.checked) {
+                  onCheckedChange={(checked) => {
+                    if (checked === true) {
                       setSupportedModes([...supportedModes, mode.id]);
                     } else {
                       setSupportedModes(
@@ -151,7 +153,7 @@ export function MapMetadataPanel() {
                     }
                   }}
                 />
-                {mode.label}
+                <span className="select-none">{mode.label}</span>
               </label>
             );
           })}

--- a/apps/client/src/features/map-editor/components/map-picker-dialog.tsx
+++ b/apps/client/src/features/map-editor/components/map-picker-dialog.tsx
@@ -1,0 +1,96 @@
+import type { CustomMap } from "@generals-plus/shared-types";
+import { useEffect, useState } from "react";
+
+import { Button } from "#/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "#/components/ui/dialog";
+import { mapsApi } from "#/features/map-editor/api/maps-api";
+
+interface MapPickerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (map: CustomMap) => void;
+}
+
+export function MapPickerDialog({
+  open,
+  onClose,
+  onSelect,
+}: MapPickerDialogProps) {
+  const [maps, setMaps] = useState<CustomMap[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError(null);
+    mapsApi
+      .list({ sort: "plays", limit: 50 })
+      .then((res) => setMaps(res.maps))
+      .catch((err) =>
+        setError(err instanceof Error ? err.message : "Failed to load maps"),
+      )
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent
+        className="max-h-[80vh] overflow-auto border-game-border bg-game-surface text-game-text sm:max-w-3xl"
+        aria-describedby={undefined}
+        showCloseButton={true}
+      >
+        <DialogHeader>
+          <DialogTitle>Select a custom map</DialogTitle>
+        </DialogHeader>
+
+        {loading && <p className="text-game-text-dim">Loading...</p>}
+        {error && <p className="text-red-400">{error}</p>}
+        {!loading && !error && maps.length === 0 && (
+          <p className="text-game-text-dim">No published maps available yet.</p>
+        )}
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {maps.map((map) => (
+            <button
+              type="button"
+              key={map.id}
+              onClick={() => {
+                onSelect(map);
+                onClose();
+              }}
+              className="border border-game-border bg-game-bg p-3 text-left hover:bg-game-surface"
+            >
+              <h4 className="font-semibold">{map.name}</h4>
+              <p className="text-xs text-game-text-dim">
+                by {map.authorName} ·{" "}
+                {map.minPlayers === map.maxPlayers
+                  ? `${map.minPlayers} players`
+                  : `${map.minPlayers}-${map.maxPlayers} players`}
+              </p>
+              <p className="text-xs text-game-text-dim">
+                modes: {map.supportedModes.join(", ") || "—"}
+              </p>
+              {map.description && (
+                <p className="mt-1 line-clamp-2 text-sm text-game-text-dim">
+                  {map.description}
+                </p>
+              )}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-3 text-right">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/client/src/features/map-editor/components/tool-palette.tsx
+++ b/apps/client/src/features/map-editor/components/tool-palette.tsx
@@ -275,7 +275,7 @@ export function ToolPalette() {
           <div className="flex flex-col gap-2">
             {/* Flag Card */}
             {showFlag && (
-              <div className="bg-game-bg/40 border border-game-border/40 rounded-lg p-2.5 flex flex-col gap-2">
+              <div className="bg-game-bg/40 border border-game-border/40 rounded-none p-2.5 flex flex-col gap-2">
                 <span className="text-[10px] font-bold text-game-text flex items-center gap-1.5 uppercase tracking-wide">
                   <img
                     src={flagIcon}
@@ -296,7 +296,7 @@ export function ToolPalette() {
 
             {/* Bomb Site Card */}
             {showBomb && (
-              <div className="bg-game-bg/40 border border-game-border/40 rounded-lg p-2.5 flex flex-col gap-2">
+              <div className="bg-game-bg/40 border border-game-border/40 rounded-none p-2.5 flex flex-col gap-2">
                 <span className="text-[10px] font-bold text-game-text flex items-center gap-1.5 uppercase tracking-wide">
                   <img
                     src={bombNormalIcon}
@@ -317,7 +317,7 @@ export function ToolPalette() {
 
             {/* Payload Track Card */}
             {showTrack && (
-              <div className="bg-game-bg/40 border border-game-border/40 rounded-lg p-2.5 flex flex-col gap-2">
+              <div className="bg-game-bg/40 border border-game-border/40 rounded-none p-2.5 flex flex-col gap-2">
                 <span className="text-[10px] font-bold text-game-text flex items-center gap-1.5 uppercase tracking-wide">
                   <Route className="size-3.5 text-white/80" />
                   Payload Track Route

--- a/apps/client/src/features/map-editor/components/tool-palette.tsx
+++ b/apps/client/src/features/map-editor/components/tool-palette.tsx
@@ -97,7 +97,7 @@ export function ToolPalette() {
         variant="outline"
         onClick={() => setTool(target)}
         className={cn(
-          "h-8 justify-start gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-all text-xs px-2.5",
+          "h-8 justify-start gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-colors text-xs px-2.5",
           isSelected &&
             "ring-2 ring-white/60 bg-white/10 text-white font-medium border-white/30",
           className,
@@ -129,14 +129,14 @@ export function ToolPalette() {
   const showModeObjectivesSection = showFlag || showBomb || showTrack;
 
   return (
-    <div className="flex flex-col gap-5 p-4 bg-game-surface/60 backdrop-blur-md h-full">
+    <div className="flex flex-col gap-5 p-4 bg-game-surface h-full">
       {/* Undo/Redo Header - Left Aligned */}
       <div className="flex gap-2 border-b border-game-border/30 pb-3">
         <Button
           type="button"
           variant="outline"
           onClick={undo}
-          className="flex-1 h-8 justify-start px-2.5 gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-all text-xs"
+          className="flex-1 h-8 justify-start px-2.5 gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-colors text-xs"
         >
           <Undo className="size-3.5" /> Undo
         </Button>
@@ -144,7 +144,7 @@ export function ToolPalette() {
           type="button"
           variant="outline"
           onClick={redo}
-          className="flex-1 h-8 justify-start px-2.5 gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-all text-xs"
+          className="flex-1 h-8 justify-start px-2.5 gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-colors text-xs"
         >
           <Redo className="size-3.5" /> Redo
         </Button>

--- a/apps/client/src/features/map-editor/components/tool-palette.tsx
+++ b/apps/client/src/features/map-editor/components/tool-palette.tsx
@@ -1,0 +1,191 @@
+import { Terrain } from "@generals-plus/engine";
+import { Redo, Undo } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "#/components/ui/button";
+import { Input } from "#/components/ui/input";
+import { Label } from "#/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#/components/ui/select";
+import type { EditorTool } from "#/features/map-editor/store/editor-store";
+import { useEditorStore } from "#/features/map-editor/store/editor-store";
+import { cn } from "#/lib/utils";
+
+const TERRAIN_PALETTE: { terrain: Terrain; label: string; color: string }[] = [
+  { terrain: Terrain.PLAIN, label: "Plain", color: "#d8dde3" },
+  { terrain: Terrain.MOUNTAIN, label: "Mountain", color: "#9da8b6" },
+  { terrain: Terrain.SWAMP, label: "Swamp", color: "#4f8a6f" },
+  { terrain: Terrain.DESERT, label: "Desert", color: "#e5cf8d" },
+  { terrain: Terrain.VOID, label: "Void", color: "#111111" },
+  { terrain: Terrain.FLAG, label: "Flag", color: "#8aa4c8" },
+];
+
+function toolMatches(a: EditorTool, b: EditorTool): boolean {
+  if (a.kind !== b.kind) return false;
+  if (a.kind === "terrain" && b.kind === "terrain")
+    return a.terrain === b.terrain;
+  if (a.kind === "city" && b.kind === "city")
+    return a.troopCount === b.troopCount;
+  if (a.kind === "general" && b.kind === "general")
+    return a.teamId === b.teamId && a.slot === b.slot;
+  return true;
+}
+
+export function ToolPalette() {
+  const tool = useEditorStore((s) => s.tool);
+  const setTool = useEditorStore((s) => s.setTool);
+  const undo = useEditorStore((s) => s.undo);
+  const redo = useEditorStore((s) => s.redo);
+  const supportedModes = useEditorStore((s) => s.supportedModes);
+
+  const [cityTroops, setCityTroops] = useState(50);
+  const [generalTeam, setGeneralTeam] = useState("team_0");
+  const [generalSlot, setGeneralSlot] = useState(0);
+
+  const ToolButton = ({
+    target,
+    children,
+    className,
+  }: {
+    target: EditorTool;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={() => setTool(target)}
+      className={cn(
+        "h-9 justify-start gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface",
+        toolMatches(tool, target) && "ring-2 ring-white/70",
+        className,
+      )}
+    >
+      {children}
+    </Button>
+  );
+
+  return (
+    <div className="grid gap-3 p-3">
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={undo}
+          className="h-8 border-game-border bg-game-bg text-game-text"
+        >
+          <Undo className="size-4" /> Undo
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={redo}
+          className="h-8 border-game-border bg-game-bg text-game-text"
+        >
+          <Redo className="size-4" /> Redo
+        </Button>
+      </div>
+
+      <div>
+        <Label className="text-xs text-game-text-dim">Terrain</Label>
+        <div className="mt-1 grid grid-cols-2 gap-1.5">
+          {TERRAIN_PALETTE.map((t) => (
+            <ToolButton
+              key={t.terrain}
+              target={{ kind: "terrain", terrain: t.terrain }}
+            >
+              <span
+                className="inline-block size-4 border border-black/30"
+                style={{ background: t.color }}
+              />
+              {t.label}
+            </ToolButton>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <Label className="text-xs text-game-text-dim">City</Label>
+        <div className="mt-1 grid grid-cols-[1fr_auto] gap-2">
+          <Input
+            type="number"
+            min={0}
+            value={cityTroops}
+            onChange={(e) => setCityTroops(Number(e.target.value))}
+            className="h-8 border-game-border bg-game-bg text-sm text-game-text"
+          />
+          <ToolButton
+            target={{ kind: "city", troopCount: cityTroops }}
+            className="px-3"
+          >
+            Place City
+          </ToolButton>
+        </div>
+      </div>
+
+      <div>
+        <Label className="text-xs text-game-text-dim">General (spawn)</Label>
+        <div className="mt-1 grid grid-cols-[1fr_1fr_auto] gap-2">
+          <Select value={generalTeam} onValueChange={setGeneralTeam}>
+            <SelectTrigger
+              size="sm"
+              className="h-8 border-game-border bg-game-bg px-2 text-xs text-game-text"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="border-game-border bg-game-surface text-game-text">
+              {[
+                "team_0",
+                "team_1",
+                "team_2",
+                "team_3",
+                "attackers",
+                "defenders",
+              ].map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            type="number"
+            min={0}
+            value={generalSlot}
+            onChange={(e) => setGeneralSlot(Number(e.target.value))}
+            className="h-8 border-game-border bg-game-bg text-sm text-game-text"
+          />
+          <ToolButton
+            target={{ kind: "general", teamId: generalTeam, slot: generalSlot }}
+            className="px-3"
+          >
+            Place
+          </ToolButton>
+        </div>
+      </div>
+
+      <div>
+        <Label className="text-xs text-game-text-dim">Mode elements</Label>
+        <div className="mt-1 grid grid-cols-2 gap-1.5">
+          <ToolButton target={{ kind: "bombSite" }}>Bomb Site</ToolButton>
+          <ToolButton target={{ kind: "erase" }}>Erase</ToolButton>
+        </div>
+      </div>
+
+      {supportedModes.some((m) => m === "payload") && (
+        <div>
+          <Label className="text-xs text-game-text-dim">Payload track</Label>
+          <div className="mt-1 grid grid-cols-2 gap-1.5">
+            <ToolButton target={{ kind: "trackAdd" }}>+ Track</ToolButton>
+            <ToolButton target={{ kind: "trackRemove" }}>- Track</ToolButton>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/client/src/features/map-editor/components/tool-palette.tsx
+++ b/apps/client/src/features/map-editor/components/tool-palette.tsx
@@ -1,6 +1,6 @@
 import { Terrain } from "@generals-plus/engine";
-import { Redo, Undo } from "lucide-react";
-import { useState } from "react";
+import { Ban, Eraser, Grid, Redo, Route, Trash2, Undo } from "lucide-react";
+import { useEffect, useState } from "react";
 
 import { Button } from "#/components/ui/button";
 import { Input } from "#/components/ui/input";
@@ -12,18 +12,18 @@ import {
   SelectTrigger,
   SelectValue,
 } from "#/components/ui/select";
+import {
+  bombNormalIcon,
+  cityIcon,
+  crownIcon,
+  desertIcon,
+  flagIcon,
+  mountainIcon,
+  swampIcon,
+} from "#/features/game/assets";
 import type { EditorTool } from "#/features/map-editor/store/editor-store";
 import { useEditorStore } from "#/features/map-editor/store/editor-store";
 import { cn } from "#/lib/utils";
-
-const TERRAIN_PALETTE: { terrain: Terrain; label: string; color: string }[] = [
-  { terrain: Terrain.PLAIN, label: "Plain", color: "#d8dde3" },
-  { terrain: Terrain.MOUNTAIN, label: "Mountain", color: "#9da8b6" },
-  { terrain: Terrain.SWAMP, label: "Swamp", color: "#4f8a6f" },
-  { terrain: Terrain.DESERT, label: "Desert", color: "#e5cf8d" },
-  { terrain: Terrain.VOID, label: "Void", color: "#111111" },
-  { terrain: Terrain.FLAG, label: "Flag", color: "#8aa4c8" },
-];
 
 function toolMatches(a: EditorTool, b: EditorTool): boolean {
   if (a.kind !== b.kind) return false;
@@ -47,145 +47,312 @@ export function ToolPalette() {
   const [generalTeam, setGeneralTeam] = useState("team_0");
   const [generalSlot, setGeneralSlot] = useState(0);
 
+  // Sync inputs with the store's current active tool state
+  useEffect(() => {
+    if (tool.kind === "general") {
+      setGeneralTeam(tool.teamId);
+      setGeneralSlot(tool.slot);
+    } else if (tool.kind === "city") {
+      setCityTroops(tool.troopCount);
+    }
+  }, [tool]);
+
+  const handleTeamSelect = (teamId: string) => {
+    setGeneralTeam(teamId);
+    setGeneralSlot(0); // Reset index to 0 when team changes
+    setTool({ kind: "general", teamId, slot: 0 });
+  };
+
+  const handleSlotChange = (slotVal: number) => {
+    const val = Math.max(0, slotVal);
+    setGeneralSlot(val);
+    setTool({ kind: "general", teamId: generalTeam, slot: val });
+  };
+
+  const handleCityTroopsChange = (troops: number) => {
+    const val = Math.max(0, troops);
+    setCityTroops(val);
+    setTool({ kind: "city", troopCount: val });
+  };
+
   const ToolButton = ({
     target,
-    children,
+    label,
+    color,
+    lucideIcon: LucideIcon,
+    gameIcon,
     className,
   }: {
     target: EditorTool;
-    children: React.ReactNode;
+    label: string;
+    color?: string;
+    lucideIcon?: React.ComponentType<{ className?: string }>;
+    gameIcon?: string;
     className?: string;
-  }) => (
-    <Button
-      type="button"
-      variant="outline"
-      onClick={() => setTool(target)}
-      className={cn(
-        "h-9 justify-start gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface",
-        toolMatches(tool, target) && "ring-2 ring-white/70",
-        className,
-      )}
-    >
-      {children}
-    </Button>
-  );
+  }) => {
+    const isSelected = toolMatches(tool, target);
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => setTool(target)}
+        className={cn(
+          "h-8 justify-start gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-all text-xs px-2.5",
+          isSelected &&
+            "ring-2 ring-white/60 bg-white/10 text-white font-medium border-white/30",
+          className,
+        )}
+      >
+        {gameIcon ? (
+          <img
+            src={gameIcon}
+            className="size-4.5 object-contain"
+            style={{ filter: "brightness(0) invert(1)" }}
+            alt={label}
+          />
+        ) : LucideIcon ? (
+          <LucideIcon className="size-4 opacity-80" />
+        ) : color ? (
+          <span
+            className="inline-block size-3 rounded-sm border border-black/30 shadow-inner"
+            style={{ background: color }}
+          />
+        ) : null}
+        <span className="truncate">{label}</span>
+      </Button>
+    );
+  };
+
+  const showFlag = supportedModes.includes("domination");
+  const showBomb = supportedModes.includes("demolition");
+  const showTrack = supportedModes.includes("payload");
+  const showModeObjectivesSection = showFlag || showBomb || showTrack;
 
   return (
-    <div className="grid gap-3 p-3">
-      <div className="flex gap-2">
+    <div className="flex flex-col gap-5 p-4 bg-game-surface/60 backdrop-blur-md h-full">
+      {/* Undo/Redo Header - Left Aligned */}
+      <div className="flex gap-2 border-b border-game-border/30 pb-3">
         <Button
           type="button"
           variant="outline"
           onClick={undo}
-          className="h-8 border-game-border bg-game-bg text-game-text"
+          className="flex-1 h-8 justify-start px-2.5 gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-all text-xs"
         >
-          <Undo className="size-4" /> Undo
+          <Undo className="size-3.5" /> Undo
         </Button>
         <Button
           type="button"
           variant="outline"
           onClick={redo}
-          className="h-8 border-game-border bg-game-bg text-game-text"
+          className="flex-1 h-8 justify-start px-2.5 gap-2 border-game-border bg-game-bg text-game-text hover:bg-game-surface hover:text-white transition-all text-xs"
         >
-          <Redo className="size-4" /> Redo
+          <Redo className="size-3.5" /> Redo
         </Button>
       </div>
 
-      <div>
-        <Label className="text-xs text-game-text-dim">Terrain</Label>
-        <div className="mt-1 grid grid-cols-2 gap-1.5">
-          {TERRAIN_PALETTE.map((t) => (
-            <ToolButton
-              key={t.terrain}
-              target={{ kind: "terrain", terrain: t.terrain }}
-            >
-              <span
-                className="inline-block size-4 border border-black/30"
-                style={{ background: t.color }}
-              />
-              {t.label}
-            </ToolButton>
-          ))}
-        </div>
-      </div>
-
-      <div>
-        <Label className="text-xs text-game-text-dim">City</Label>
-        <div className="mt-1 grid grid-cols-[1fr_auto] gap-2">
-          <Input
-            type="number"
-            min={0}
-            value={cityTroops}
-            onChange={(e) => setCityTroops(Number(e.target.value))}
-            className="h-8 border-game-border bg-game-bg text-sm text-game-text"
-          />
+      {/* 1. Base Terrains */}
+      <div className="flex flex-col gap-2">
+        <Label className="text-xs font-bold tracking-wider text-game-text-dim uppercase">
+          Base Terrains
+        </Label>
+        <div className="grid grid-cols-2 gap-2">
+          {/* Plain */}
           <ToolButton
-            target={{ kind: "city", troopCount: cityTroops }}
-            className="px-3"
-          >
-            Place City
-          </ToolButton>
-        </div>
-      </div>
-
-      <div>
-        <Label className="text-xs text-game-text-dim">General (spawn)</Label>
-        <div className="mt-1 grid grid-cols-[1fr_1fr_auto] gap-2">
-          <Select value={generalTeam} onValueChange={setGeneralTeam}>
-            <SelectTrigger
-              size="sm"
-              className="h-8 border-game-border bg-game-bg px-2 text-xs text-game-text"
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className="border-game-border bg-game-surface text-game-text">
-              {[
-                "team_0",
-                "team_1",
-                "team_2",
-                "team_3",
-                "attackers",
-                "defenders",
-              ].map((t) => (
-                <SelectItem key={t} value={t}>
-                  {t}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Input
-            type="number"
-            min={0}
-            value={generalSlot}
-            onChange={(e) => setGeneralSlot(Number(e.target.value))}
-            className="h-8 border-game-border bg-game-bg text-sm text-game-text"
+            target={{ kind: "terrain", terrain: Terrain.PLAIN }}
+            label="Plain"
+            color="#d8dde3"
+            lucideIcon={Grid}
           />
+          {/* Mountain */}
           <ToolButton
-            target={{ kind: "general", teamId: generalTeam, slot: generalSlot }}
-            className="px-3"
-          >
-            Place
-          </ToolButton>
+            target={{ kind: "terrain", terrain: Terrain.MOUNTAIN }}
+            label="Mountain"
+            color="#9da8b6"
+            gameIcon={mountainIcon}
+          />
+          {/* Swamp */}
+          <ToolButton
+            target={{ kind: "terrain", terrain: Terrain.SWAMP }}
+            label="Swamp"
+            color="#4f8a6f"
+            gameIcon={swampIcon}
+          />
+          {/* Desert */}
+          <ToolButton
+            target={{ kind: "terrain", terrain: Terrain.DESERT }}
+            label="Desert"
+            color="#e5cf8d"
+            gameIcon={desertIcon}
+          />
+          {/* Void */}
+          <ToolButton
+            target={{ kind: "terrain", terrain: Terrain.VOID }}
+            label="Void"
+            color="#111111"
+            lucideIcon={Ban}
+          />
         </div>
       </div>
 
-      <div>
-        <Label className="text-xs text-game-text-dim">Mode elements</Label>
-        <div className="mt-1 grid grid-cols-2 gap-1.5">
-          <ToolButton target={{ kind: "bombSite" }}>Bomb Site</ToolButton>
-          <ToolButton target={{ kind: "erase" }}>Erase</ToolButton>
-        </div>
-      </div>
+      {/* 2. Structures & Players */}
+      <div className="flex flex-col gap-3 border-t border-game-border/30 pt-3">
+        <Label className="text-xs font-bold tracking-wider text-game-text-dim uppercase">
+          Structures & Players
+        </Label>
 
-      {supportedModes.some((m) => m === "payload") && (
+        {/* City Tool Row: Left is 70px troops input, Right is wider Place City button */}
         <div>
-          <Label className="text-xs text-game-text-dim">Payload track</Label>
-          <div className="mt-1 grid grid-cols-2 gap-1.5">
-            <ToolButton target={{ kind: "trackAdd" }}>+ Track</ToolButton>
-            <ToolButton target={{ kind: "trackRemove" }}>- Track</ToolButton>
+          <Label className="text-xs text-game-text-dim">Neutral City</Label>
+          <div className="mt-1 grid grid-cols-[70px_1fr] gap-1.5">
+            <Input
+              type="number"
+              min={0}
+              value={cityTroops}
+              onChange={(e) => handleCityTroopsChange(Number(e.target.value))}
+              className="h-8 border-game-border bg-game-bg text-xs text-game-text text-left px-2.5 w-full"
+              placeholder="Troops"
+            />
+            <ToolButton
+              target={{ kind: "city", troopCount: cityTroops }}
+              label="Place City"
+              gameIcon={cityIcon}
+              className="w-full"
+            />
+          </div>
+        </div>
+
+        {/* General Spawn Tool Row: Team is 100px, Slot is 50px, Place is wider 1fr */}
+        <div>
+          <Label className="text-xs text-game-text-dim">General (spawn)</Label>
+          <div className="mt-1 grid grid-cols-[100px_50px_1fr] gap-1.5">
+            <Select value={generalTeam} onValueChange={handleTeamSelect}>
+              <SelectTrigger className="h-8 border-game-border bg-game-bg px-2.5 text-xs text-game-text focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 w-full py-0">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="border-game-border bg-game-surface text-game-text">
+                {[
+                  "team_0",
+                  "team_1",
+                  "team_2",
+                  "team_3",
+                  "attackers",
+                  "defenders",
+                ].map((t) => (
+                  <SelectItem key={t} value={t} className="text-xs">
+                    {t}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Input
+              type="number"
+              min={0}
+              value={generalSlot}
+              onChange={(e) => handleSlotChange(Number(e.target.value))}
+              className="h-8 border-game-border bg-game-bg text-xs text-game-text text-left px-2.5 w-full"
+              placeholder="Slot"
+            />
+            <ToolButton
+              target={{
+                kind: "general",
+                teamId: generalTeam,
+                slot: generalSlot,
+              }}
+              label="Place"
+              gameIcon={crownIcon}
+              className="w-full"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* 3. Game Mode Objectives (Conditional) */}
+      {showModeObjectivesSection && (
+        <div className="flex flex-col gap-2 border-t border-game-border/30 pt-3">
+          <Label className="text-xs font-bold tracking-wider text-game-text-dim uppercase">
+            Game Mode Objectives
+          </Label>
+          <div className="flex flex-col gap-2">
+            {/* Flag Card */}
+            {showFlag && (
+              <div className="bg-game-bg/40 border border-game-border/40 rounded-lg p-2.5 flex flex-col gap-2">
+                <span className="text-[10px] font-bold text-game-text flex items-center gap-1.5 uppercase tracking-wide">
+                  <img
+                    src={flagIcon}
+                    className="size-3.5 object-contain"
+                    style={{ filter: "brightness(0) invert(1)" }}
+                    alt="Flag"
+                  />
+                  Domination Flag
+                </span>
+                <ToolButton
+                  target={{ kind: "terrain", terrain: Terrain.FLAG }}
+                  label="Place Flag"
+                  gameIcon={flagIcon}
+                  className="w-full"
+                />
+              </div>
+            )}
+
+            {/* Bomb Site Card */}
+            {showBomb && (
+              <div className="bg-game-bg/40 border border-game-border/40 rounded-lg p-2.5 flex flex-col gap-2">
+                <span className="text-[10px] font-bold text-game-text flex items-center gap-1.5 uppercase tracking-wide">
+                  <img
+                    src={bombNormalIcon}
+                    className="size-3.5 object-contain"
+                    style={{ filter: "brightness(0) invert(1)" }}
+                    alt="Bomb"
+                  />
+                  Demolition Objective
+                </span>
+                <ToolButton
+                  target={{ kind: "bombSite" }}
+                  label="Place Bomb Site"
+                  gameIcon={bombNormalIcon}
+                  className="w-full"
+                />
+              </div>
+            )}
+
+            {/* Payload Track Card */}
+            {showTrack && (
+              <div className="bg-game-bg/40 border border-game-border/40 rounded-lg p-2.5 flex flex-col gap-2">
+                <span className="text-[10px] font-bold text-game-text flex items-center gap-1.5 uppercase tracking-wide">
+                  <Route className="size-3.5 text-white/80" />
+                  Payload Track Route
+                </span>
+                <div className="grid grid-cols-2 gap-1.5">
+                  <ToolButton
+                    target={{ kind: "trackAdd" }}
+                    label="+ Track"
+                    lucideIcon={Route}
+                  />
+                  <ToolButton
+                    target={{ kind: "trackRemove" }}
+                    label="- Track"
+                    lucideIcon={Trash2}
+                  />
+                </div>
+              </div>
+            )}
           </div>
         </div>
       )}
+
+      {/* 4. Utilities */}
+      <div className="flex flex-col gap-2 border-t border-game-border/30 pt-3 mt-auto">
+        <div className="grid grid-cols-2 gap-2">
+          <ToolButton
+            target={{ kind: "erase" }}
+            label="Erase Cell"
+            lucideIcon={Eraser}
+            className="border-red-950/20 hover:border-red-900/30 text-red-200"
+          />
+        </div>
+      </div>
     </div>
   );
 }
+
+export default ToolPalette;

--- a/apps/client/src/features/map-editor/pages/map-browser-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-browser-page.tsx
@@ -4,6 +4,13 @@ import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router";
 
 import { Button } from "#/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "#/components/ui/select";
 import { AuthStatus } from "#/features/auth/auth-store";
 import { useAuth, useUser } from "#/features/auth/hooks";
 import { mapsApi } from "#/features/map-editor/api/maps-api";
@@ -74,15 +81,25 @@ export function MapBrowserPage() {
           <h1 className="text-lg font-semibold">Custom Maps</h1>
         </div>
         <div className="flex items-center gap-2">
-          <select
+          <Select
             value={sort}
-            onChange={(e) => setSort(e.target.value as SortOption)}
-            className="h-8 border border-game-border bg-game-bg px-2 text-sm text-game-text"
+            onValueChange={(val) => setSort(val as SortOption)}
           >
-            <option value="date">Newest</option>
-            <option value="plays">Most plays</option>
-            <option value="likes">Most likes</option>
-          </select>
+            <SelectTrigger className="h-8 border-game-border bg-game-bg px-2.5 text-xs text-game-text focus:ring-0 focus:ring-offset-0 focus-visible:ring-0 w-[120px] py-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="border-game-border bg-game-surface text-game-text">
+              <SelectItem value="date" className="text-xs">
+                Newest
+              </SelectItem>
+              <SelectItem value="plays" className="text-xs">
+                Most plays
+              </SelectItem>
+              <SelectItem value="likes" className="text-xs">
+                Most likes
+              </SelectItem>
+            </SelectContent>
+          </Select>
           {state.status === AuthStatus.AUTHENTICATED && (
             <Button asChild>
               <Link to="/map-editor">

--- a/apps/client/src/features/map-editor/pages/map-browser-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-browser-page.tsx
@@ -1,0 +1,224 @@
+import type { CustomMap } from "@generals-plus/shared-types";
+import { ArrowLeft, Heart, Pencil, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router";
+
+import { Button } from "#/components/ui/button";
+import { AuthStatus } from "#/features/auth/auth-store";
+import { useAuth, useUser } from "#/features/auth/hooks";
+import { mapsApi } from "#/features/map-editor/api/maps-api";
+
+type SortOption = "date" | "plays" | "likes";
+
+export function MapBrowserPage() {
+  const navigate = useNavigate();
+  const { state } = useAuth();
+  const userId = useUser((u) => u?.id);
+
+  const [maps, setMaps] = useState<CustomMap[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [sort, setSort] = useState<SortOption>("date");
+  const [total, setTotal] = useState(0);
+  const limit = 12;
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    mapsApi
+      .list({ page, limit, sort })
+      .then((res) => {
+        setMaps(res.maps);
+        setTotal(res.total);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Failed to load maps");
+      })
+      .finally(() => setLoading(false));
+  }, [page, sort]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const onDelete = async (id: string) => {
+    if (!confirm("Delete this map? This cannot be undone.")) return;
+    try {
+      await mapsApi.remove(id);
+      load();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Delete failed");
+    }
+  };
+
+  const onLike = async (id: string) => {
+    try {
+      await mapsApi.toggleLike(id);
+      load();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "Like failed");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-game-bg text-game-text">
+      <header className="flex items-center justify-between border-b border-game-border bg-game-surface px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/">
+              <ArrowLeft className="size-4" />
+              Back
+            </Link>
+          </Button>
+          <h1 className="text-lg font-semibold">Custom Maps</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={sort}
+            onChange={(e) => setSort(e.target.value as SortOption)}
+            className="h-8 border border-game-border bg-game-bg px-2 text-sm text-game-text"
+          >
+            <option value="date">Newest</option>
+            <option value="plays">Most plays</option>
+            <option value="likes">Most likes</option>
+          </select>
+          {state.status === AuthStatus.AUTHENTICATED && (
+            <Button asChild>
+              <Link to="/map-editor">
+                <Plus className="size-4" />
+                New Map
+              </Link>
+            </Button>
+          )}
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl p-4">
+        {loading && (
+          <p className="text-center text-game-text-dim">Loading...</p>
+        )}
+        {error && <p className="text-center text-red-400">{error}</p>}
+        {!loading && !error && maps.length === 0 && (
+          <p className="text-center text-game-text-dim">
+            No published maps yet. Be the first to create one!
+          </p>
+        )}
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {maps.map((map) => (
+            <MapCard
+              key={map.id}
+              map={map}
+              isOwner={userId === map.authorId}
+              onEdit={() =>
+                navigate(`/map-editor?id=${encodeURIComponent(map.id)}`)
+              }
+              onDelete={() => onDelete(map.id)}
+              onLike={() => onLike(map.id)}
+            />
+          ))}
+        </div>
+
+        {total > limit && (
+          <div className="mt-4 flex items-center justify-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={page === 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+            >
+              Prev
+            </Button>
+            <span className="text-sm text-game-text-dim">
+              Page {page} / {Math.ceil(total / limit)}
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={page >= Math.ceil(total / limit)}
+              onClick={() => setPage((p) => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function MapCard({
+  map,
+  isOwner,
+  onEdit,
+  onDelete,
+  onLike,
+}: {
+  map: CustomMap;
+  isOwner: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+  onLike: () => void;
+}) {
+  return (
+    <div className="border border-game-border bg-game-surface p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate font-semibold">{map.name}</h3>
+          <p className="text-xs text-game-text-dim">by {map.authorName}</p>
+        </div>
+      </div>
+      {map.description && (
+        <p className="mt-2 line-clamp-2 text-sm text-game-text-dim">
+          {map.description}
+        </p>
+      )}
+      <p className="mt-2 text-xs text-game-text-dim">
+        {map.minPlayers === map.maxPlayers
+          ? `${map.minPlayers} players`
+          : `${map.minPlayers}-${map.maxPlayers} players`}{" "}
+        · {map.supportedModes.join(", ") || "no modes"}
+      </p>
+      <div className="mt-3 flex items-center justify-between">
+        <div className="flex items-center gap-3 text-xs text-game-text-dim">
+          <span>{map.stats.plays} plays</span>
+          <button
+            type="button"
+            onClick={onLike}
+            className="flex items-center gap-1 hover:text-pink-400"
+          >
+            <Heart className="size-3" />
+            {map.stats.likes}
+          </button>
+        </div>
+        <div className="flex items-center gap-1">
+          {isOwner && (
+            <>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={onEdit}
+                className="h-7 px-2"
+              >
+                <Pencil className="size-3" />
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={onDelete}
+                className="h-7 px-2 text-red-400 hover:text-red-300"
+              >
+                <Trash2 className="size-3" />
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MapBrowserPage;

--- a/apps/client/src/features/map-editor/pages/map-browser-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-browser-page.tsx
@@ -36,7 +36,7 @@ export function MapBrowserPage() {
         setError(err instanceof Error ? err.message : "Failed to load maps");
       })
       .finally(() => setLoading(false));
-  }, [page, sort]);
+  }, [page, limit, sort]);
 
   useEffect(() => {
     load();

--- a/apps/client/src/features/map-editor/pages/map-browser-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-browser-page.tsx
@@ -36,7 +36,7 @@ export function MapBrowserPage() {
         setError(err instanceof Error ? err.message : "Failed to load maps");
       })
       .finally(() => setLoading(false));
-  }, [page, limit, sort]);
+  }, [page, sort]);
 
   useEffect(() => {
     load();

--- a/apps/client/src/features/map-editor/pages/map-editor-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-editor-page.tsx
@@ -85,6 +85,7 @@ export function MapEditorPage() {
 
   const canSave =
     name.trim().length > 0 &&
+    supportedModes.length > 0 &&
     spawns.length >= 2 &&
     spawns.length === generalCount;
 

--- a/apps/client/src/features/map-editor/pages/map-editor-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-editor-page.tsx
@@ -1,0 +1,211 @@
+import { Terrain } from "@generals-plus/engine";
+import { ArrowLeft, Save } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useSearchParams } from "react-router";
+
+import { Button } from "#/components/ui/button";
+import { AuthStatus } from "#/features/auth/auth-store";
+import { useAuth, useUser } from "#/features/auth/hooks";
+import { mapsApi } from "#/features/map-editor/api/maps-api";
+import { EditorCanvas } from "#/features/map-editor/components/editor-canvas";
+import { MapMetadataPanel } from "#/features/map-editor/components/map-metadata-panel";
+import { ToolPalette } from "#/features/map-editor/components/tool-palette";
+import { useEditorStore } from "#/features/map-editor/store/editor-store";
+
+const TEAM_COLORS: Record<string, number> = {
+  team_0: 0xef4444,
+  team_1: 0x3b82f6,
+  team_2: 0x10b981,
+  team_3: 0xf59e0b,
+  attackers: 0xef4444,
+  defenders: 0x3b82f6,
+};
+
+export function MapEditorPage() {
+  const [params] = useSearchParams();
+  const editId = params.get("id");
+
+  const { state } = useAuth();
+  const user = useUser((u) => u);
+
+  const reset = useEditorStore((s) => s.reset);
+  const loadFromMap = useEditorStore((s) => s.loadFromMap);
+  const mapId = useEditorStore((s) => s.mapId);
+  const cells = useEditorStore((s) => s.cells);
+  const spawns = useEditorStore((s) => s.spawns);
+  const supportedModes = useEditorStore((s) => s.supportedModes);
+  const name = useEditorStore((s) => s.name);
+  const description = useEditorStore((s) => s.description);
+  const saving = useEditorStore((s) => s.saving);
+  const saveError = useEditorStore((s) => s.saveError);
+  const setSaving = useEditorStore((s) => s.setSaving);
+  const setSaveError = useEditorStore((s) => s.setSaveError);
+  const setLastSavedAt = useEditorStore((s) => s.setLastSavedAt);
+  const setMapId = useEditorStore((s) => s.setMapId);
+  const getTemplate = useEditorStore((s) => s.getTemplate);
+
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!editId) {
+      reset();
+      return;
+    }
+    let cancelled = false;
+    mapsApi
+      .get(editId)
+      .then((map) => {
+        if (cancelled) return;
+        loadFromMap(map);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : "Failed to load map");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [editId, reset, loadFromMap]);
+
+  const playerColorByTeam = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const [id, color] of Object.entries(TEAM_COLORS)) {
+      map.set(id, color);
+    }
+    return map;
+  }, []);
+
+  const generalCount = useMemo(() => {
+    let count = 0;
+    for (const row of cells) {
+      for (const c of row) if (c.terrain === Terrain.GENERAL) count++;
+    }
+    return count;
+  }, [cells]);
+
+  const canSave =
+    name.trim().length > 0 &&
+    spawns.length >= 2 &&
+    spawns.length === generalCount;
+
+  const onSave = async (publish: boolean) => {
+    if (state.status !== AuthStatus.AUTHENTICATED) {
+      setSaveError("Please sign in to save maps");
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const payload = {
+        name: name.trim(),
+        description: description.trim(),
+        grid: getTemplate(),
+        supportedModes,
+        minPlayers: spawns.length,
+        maxPlayers: spawns.length,
+        status: (publish ? "published" : "draft") as "published" | "draft",
+      };
+
+      if (mapId) {
+        await mapsApi.update(mapId, payload);
+      } else {
+        const created = await mapsApi.create(payload);
+        setMapId(created.id);
+      }
+      setLastSavedAt(Date.now());
+    } catch (err) {
+      const detail =
+        err && typeof err === "object" && "details" in err
+          ? JSON.stringify((err as { details: unknown }).details)
+          : "";
+      setSaveError(
+        (err instanceof Error ? err.message : "Save failed") +
+          (detail ? `\n${detail}` : ""),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <div className="grid h-screen place-items-center bg-game-bg text-game-text">
+        <div className="grid gap-3 text-center">
+          <p>{loadError}</p>
+          <Button asChild variant="outline">
+            <Link to="/maps">Back to maps</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen w-screen flex-col bg-game-bg text-game-text">
+      <header className="flex items-center justify-between border-b border-game-border bg-game-surface px-4 py-2">
+        <div className="flex items-center gap-3">
+          <Button asChild variant="ghost" size="sm">
+            <Link to="/maps">
+              <ArrowLeft className="size-4" />
+              Back
+            </Link>
+          </Button>
+          <h1 className="text-sm font-semibold">
+            {mapId ? `Editing: ${name}` : "New Map"}
+          </h1>
+          <span className="text-xs text-game-text-dim">
+            {spawns.length} spawn{spawns.length !== 1 ? "s" : ""} ·{" "}
+            {generalCount} general{generalCount !== 1 ? "s" : ""}
+            {generalCount !== spawns.length && (
+              <span className="text-red-400">
+                {" "}
+                (mismatch: each general needs a spawn tag)
+              </span>
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {saveError && (
+            <span className="max-w-md truncate text-xs text-red-400">
+              {saveError}
+            </span>
+          )}
+          <Button
+            type="button"
+            variant="outline"
+            disabled={saving || !canSave || !user}
+            onClick={() => onSave(false)}
+            className="border-game-border bg-game-bg text-game-text"
+          >
+            <Save className="size-4" />
+            Save draft
+          </Button>
+          <Button
+            type="button"
+            disabled={
+              saving || !canSave || !user || supportedModes.length === 0
+            }
+            onClick={() => onSave(true)}
+          >
+            <Save className="size-4" />
+            Publish
+          </Button>
+        </div>
+      </header>
+
+      <div className="grid flex-1 grid-cols-[280px_1fr_280px] overflow-hidden">
+        <aside className="overflow-y-auto border-r border-game-border bg-game-surface">
+          <ToolPalette />
+        </aside>
+        <main className="relative">
+          <EditorCanvas playerColorByTeam={playerColorByTeam} />
+        </main>
+        <aside className="overflow-y-auto border-l border-game-border bg-game-surface">
+          <MapMetadataPanel />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export default MapEditorPage;

--- a/apps/client/src/features/map-editor/pages/map-editor-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-editor-page.tsx
@@ -194,13 +194,13 @@ export function MapEditorPage() {
       </header>
 
       <div className="grid flex-1 grid-cols-[280px_1fr_280px] overflow-hidden">
-        <aside className="overflow-y-auto border-r border-game-border bg-game-surface">
+        <aside className="w-[280px] min-w-[280px] max-w-[280px] overflow-y-auto border-r border-game-border bg-game-surface">
           <ToolPalette />
         </aside>
-        <main className="relative">
+        <main className="relative overflow-hidden">
           <EditorCanvas playerColorByTeam={playerColorByTeam} />
         </main>
-        <aside className="overflow-y-auto border-l border-game-border bg-game-surface">
+        <aside className="w-[280px] min-w-[280px] max-w-[280px] overflow-y-auto border-l border-game-border bg-game-surface">
           <MapMetadataPanel />
         </aside>
       </div>

--- a/apps/client/src/features/map-editor/pages/map-editor-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-editor-page.tsx
@@ -1,5 +1,5 @@
 import { Terrain } from "@generals-plus/engine";
-import { ArrowLeft, Save } from "lucide-react";
+import { ArrowLeft, Globe, Save } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router";
 
@@ -187,7 +187,7 @@ export function MapEditorPage() {
             }
             onClick={() => onSave(true)}
           >
-            <Save className="size-4" />
+            <Globe className="size-4" />
             Publish
           </Button>
         </div>

--- a/apps/client/src/features/map-editor/store/editor-store.ts
+++ b/apps/client/src/features/map-editor/store/editor-store.ts
@@ -140,14 +140,23 @@ function setCellAt(
 }
 
 function pushHistory<S extends EditorState>(state: S, next: Partial<S>): S {
-  const snapshot = {
-    cells: state.cells,
-    spawns: state.spawns,
-    track: state.track,
-  };
   const history = state.history.slice(0, state.historyIndex + 1);
-  history.push(snapshot);
-  if (history.length > 50) history.shift();
+
+  const nextCells = next.cells !== undefined ? next.cells : state.cells;
+  const nextSpawns = next.spawns !== undefined ? next.spawns : state.spawns;
+  const nextTrack = next.track !== undefined ? next.track : state.track;
+
+  const nextSnapshot = {
+    cells: nextCells,
+    spawns: nextSpawns,
+    track: nextTrack,
+  };
+
+  history.push(nextSnapshot);
+  if (history.length > 50) {
+    history.shift();
+  }
+
   return {
     ...state,
     ...next,
@@ -171,6 +180,7 @@ function recomputeBombSiteIndices(cells: CellTemplate[][]): CellTemplate[][] {
 function buildInitialState(): EditorState {
   const gridType = GT.SQUARE as GridType;
   const bounds = DEFAULT_SQUARE_BOUNDS;
+  const cells = createEmptyCells(gridType, bounds);
   return {
     mapId: null,
     name: "Untitled Map",
@@ -178,12 +188,12 @@ function buildInitialState(): EditorState {
     supportedModes: [] as GameMode[],
     gridType,
     bounds,
-    cells: createEmptyCells(gridType, bounds),
+    cells,
     spawns: [],
     track: [],
     tool: { kind: "terrain", terrain: T.PLAIN as Terrain },
-    history: [],
-    historyIndex: -1,
+    history: [{ cells, spawns: [], track: [] }],
+    historyIndex: 0,
     saving: false,
     lastSavedAt: null,
     saveError: null,
@@ -199,6 +209,11 @@ export const useEditorStore = create<EditorState & EditorActions>(
     },
 
     loadFromMap(map) {
+      const initialSnapshot = {
+        cells: map.grid.cells,
+        spawns: map.grid.spawns,
+        track: map.grid.track ?? [],
+      };
       set({
         mapId: map.id,
         name: map.name,
@@ -209,8 +224,8 @@ export const useEditorStore = create<EditorState & EditorActions>(
         cells: map.grid.cells,
         spawns: map.grid.spawns,
         track: map.grid.track ?? [],
-        history: [],
-        historyIndex: -1,
+        history: [initialSnapshot],
+        historyIndex: 0,
         saving: false,
         lastSavedAt: null,
         saveError: null,
@@ -237,14 +252,15 @@ export const useEditorStore = create<EditorState & EditorActions>(
     setGridType(gridType) {
       const bounds =
         gridType === GT.SQUARE ? DEFAULT_SQUARE_BOUNDS : DEFAULT_HEX_BOUNDS;
+      const cells = createEmptyCells(gridType, bounds);
       set({
         gridType,
         bounds,
-        cells: createEmptyCells(gridType, bounds),
+        cells,
         spawns: [],
         track: [],
-        history: [],
-        historyIndex: -1,
+        history: [{ cells, spawns: [], track: [] }],
+        historyIndex: 0,
       });
     },
 
@@ -439,31 +455,32 @@ export const useEditorStore = create<EditorState & EditorActions>(
 
     undo() {
       set((state) => {
-        if (state.historyIndex < 0) return state;
-        const snapshot = state.history[state.historyIndex];
+        if (state.historyIndex <= 0) return state;
+        const nextIndex = state.historyIndex - 1;
+        const snapshot = state.history[nextIndex];
         if (!snapshot) return state;
         return {
           ...state,
           cells: snapshot.cells,
           spawns: snapshot.spawns,
           track: snapshot.track,
-          historyIndex: state.historyIndex - 1,
+          historyIndex: nextIndex,
         };
       });
     },
 
     redo() {
       set((state) => {
-        const next = state.historyIndex + 1;
-        const snapshot = state.history[next];
+        const nextIndex = state.historyIndex + 1;
+        if (nextIndex >= state.history.length) return state;
+        const snapshot = state.history[nextIndex];
         if (!snapshot) return state;
-        // Note: simple impl — redo replays the next snapshot
         return {
           ...state,
           cells: snapshot.cells,
           spawns: snapshot.spawns,
           track: snapshot.track,
-          historyIndex: next,
+          historyIndex: nextIndex,
         };
       });
     },

--- a/apps/client/src/features/map-editor/store/editor-store.ts
+++ b/apps/client/src/features/map-editor/store/editor-store.ts
@@ -1,0 +1,484 @@
+import type {
+  GameMode,
+  GridType,
+  ICoordinate,
+  Terrain,
+} from "@generals-plus/engine";
+import { GridType as GT, HexGrid2D, Terrain as T } from "@generals-plus/engine";
+import type {
+  CellTemplate,
+  CustomMap,
+  GridTemplate,
+  HexGridBounds,
+  SpawnPoint,
+  SquareGridBounds,
+} from "@generals-plus/shared-types";
+import { create } from "zustand";
+
+export type EditorTool =
+  | { kind: "terrain"; terrain: Terrain }
+  | { kind: "city"; troopCount: number }
+  | { kind: "general"; teamId: string; slot: number }
+  | { kind: "bombSite" }
+  | { kind: "trackAdd" }
+  | { kind: "trackRemove" }
+  | { kind: "erase" };
+
+export interface EditorState {
+  mapId: string | null;
+  name: string;
+  description: string;
+  supportedModes: GameMode[];
+
+  gridType: GridType;
+  bounds: SquareGridBounds | HexGridBounds;
+  cells: CellTemplate[][];
+  spawns: SpawnPoint[];
+  track: ICoordinate[];
+
+  tool: EditorTool;
+
+  history: {
+    cells: CellTemplate[][];
+    spawns: SpawnPoint[];
+    track: ICoordinate[];
+  }[];
+  historyIndex: number;
+
+  saving: boolean;
+  lastSavedAt: number | null;
+  saveError: string | null;
+}
+
+interface EditorActions {
+  reset(): void;
+  loadFromMap(map: CustomMap): void;
+  setName(name: string): void;
+  setDescription(desc: string): void;
+  setSupportedModes(modes: GameMode[]): void;
+  setGridType(gridType: GridType): void;
+  setSquareBounds(bounds: SquareGridBounds): void;
+  setHexBounds(bounds: HexGridBounds): void;
+  setTool(tool: EditorTool): void;
+  paintCell(coord: ICoordinate): void;
+  undo(): void;
+  redo(): void;
+  setSaving(value: boolean): void;
+  setLastSavedAt(value: number | null): void;
+  setSaveError(value: string | null): void;
+  setMapId(id: string | null): void;
+  getTemplate(): GridTemplate;
+}
+
+const DEFAULT_SQUARE_BOUNDS: SquareGridBounds = { width: 20, height: 14 };
+const DEFAULT_HEX_BOUNDS: HexGridBounds = {
+  left: 8,
+  right: 8,
+  leftSlant: 15,
+  rightSlant: 15,
+};
+
+function createEmptyCells(
+  gridType: GridType,
+  bounds: SquareGridBounds | HexGridBounds,
+): CellTemplate[][] {
+  if (gridType === GT.SQUARE) {
+    const { width, height } = bounds as SquareGridBounds;
+    return Array.from({ length: height }, () =>
+      Array.from({ length: width }, () => ({
+        terrain: T.PLAIN as Terrain,
+        troopCount: null,
+        siteIndex: null,
+      })),
+    );
+  }
+  const { left, right, leftSlant, rightSlant } = bounds as HexGridBounds;
+  return Array.from({ length: leftSlant }, (_, y) => {
+    const minX = HexGrid2D.getMinX(y, left);
+    const maxX = HexGrid2D.getMaxX(y, right, rightSlant);
+    return Array.from({ length: maxX - minX + 1 }, () => ({
+      terrain: T.PLAIN as Terrain,
+      troopCount: null,
+      siteIndex: null,
+    }));
+  });
+}
+
+function getRowOffsetX(
+  gridType: GridType,
+  bounds: SquareGridBounds | HexGridBounds,
+  y: number,
+): number {
+  if (gridType === GT.SQUARE) return 0;
+  const { left } = bounds as HexGridBounds;
+  return HexGrid2D.getMinX(y, left);
+}
+
+function getCellAt(
+  state: EditorState,
+  coord: ICoordinate,
+): CellTemplate | null {
+  const row = state.cells[coord.y];
+  if (!row) return null;
+  const offset = getRowOffsetX(state.gridType, state.bounds, coord.y);
+  const idx = coord.x - offset;
+  return row[idx] ?? null;
+}
+
+function setCellAt(
+  state: EditorState,
+  coord: ICoordinate,
+  update: Partial<CellTemplate>,
+): CellTemplate[][] {
+  const newCells = state.cells.map((row, y) => {
+    if (y !== coord.y) return row;
+    const offset = getRowOffsetX(state.gridType, state.bounds, y);
+    const idx = coord.x - offset;
+    return row.map((cell, i) => (i === idx ? { ...cell, ...update } : cell));
+  });
+  return newCells;
+}
+
+function pushHistory<S extends EditorState>(state: S, next: Partial<S>): S {
+  const snapshot = {
+    cells: state.cells,
+    spawns: state.spawns,
+    track: state.track,
+  };
+  const history = state.history.slice(0, state.historyIndex + 1);
+  history.push(snapshot);
+  if (history.length > 50) history.shift();
+  return {
+    ...state,
+    ...next,
+    history,
+    historyIndex: history.length - 1,
+  };
+}
+
+function recomputeBombSiteIndices(cells: CellTemplate[][]): CellTemplate[][] {
+  let counter = 0;
+  return cells.map((row) =>
+    row.map((cell) => {
+      if (cell.terrain === T.BOMB_SITE) {
+        return { ...cell, siteIndex: counter++ };
+      }
+      return cell;
+    }),
+  );
+}
+
+function buildInitialState(): EditorState {
+  const gridType = GT.SQUARE as GridType;
+  const bounds = DEFAULT_SQUARE_BOUNDS;
+  return {
+    mapId: null,
+    name: "Untitled Map",
+    description: "",
+    supportedModes: [] as GameMode[],
+    gridType,
+    bounds,
+    cells: createEmptyCells(gridType, bounds),
+    spawns: [],
+    track: [],
+    tool: { kind: "terrain", terrain: T.PLAIN as Terrain },
+    history: [],
+    historyIndex: -1,
+    saving: false,
+    lastSavedAt: null,
+    saveError: null,
+  };
+}
+
+export const useEditorStore = create<EditorState & EditorActions>(
+  (set, get) => ({
+    ...buildInitialState(),
+
+    reset() {
+      set(buildInitialState());
+    },
+
+    loadFromMap(map) {
+      set({
+        mapId: map.id,
+        name: map.name,
+        description: map.description,
+        supportedModes: map.supportedModes,
+        gridType: map.grid.gridType,
+        bounds: map.grid.bounds,
+        cells: map.grid.cells,
+        spawns: map.grid.spawns,
+        track: map.grid.track ?? [],
+        history: [],
+        historyIndex: -1,
+        saving: false,
+        lastSavedAt: null,
+        saveError: null,
+        tool: { kind: "terrain", terrain: T.PLAIN as Terrain },
+      });
+    },
+
+    setMapId(id) {
+      set({ mapId: id });
+    },
+
+    setName(name) {
+      set({ name });
+    },
+
+    setDescription(description) {
+      set({ description });
+    },
+
+    setSupportedModes(supportedModes) {
+      set({ supportedModes });
+    },
+
+    setGridType(gridType) {
+      const bounds =
+        gridType === GT.SQUARE ? DEFAULT_SQUARE_BOUNDS : DEFAULT_HEX_BOUNDS;
+      set({
+        gridType,
+        bounds,
+        cells: createEmptyCells(gridType, bounds),
+        spawns: [],
+        track: [],
+        history: [],
+        historyIndex: -1,
+      });
+    },
+
+    setSquareBounds(bounds) {
+      set((state) => {
+        if (state.gridType !== GT.SQUARE) return state;
+        const newCells = createEmptyCells(GT.SQUARE, bounds);
+        // Preserve existing cells where possible
+        const oldBounds = state.bounds as SquareGridBounds;
+        for (let y = 0; y < Math.min(oldBounds.height, bounds.height); y++) {
+          for (let x = 0; x < Math.min(oldBounds.width, bounds.width); x++) {
+            newCells[y][x] = state.cells[y][x];
+          }
+        }
+        const filteredSpawns = state.spawns.filter(
+          (s) => s.x < bounds.width && s.y < bounds.height,
+        );
+        const filteredTrack = state.track.filter(
+          (c) => c.x < bounds.width && c.y < bounds.height,
+        );
+        return pushHistory(state, {
+          bounds,
+          cells: recomputeBombSiteIndices(newCells),
+          spawns: filteredSpawns,
+          track: filteredTrack,
+        });
+      });
+    },
+
+    setHexBounds(bounds) {
+      set((state) => {
+        if (state.gridType !== GT.HEX) return state;
+        const newCells = createEmptyCells(GT.HEX, bounds);
+        // Preserve where in-bounds for both old and new
+        const oldBounds = state.bounds as HexGridBounds;
+        for (let y = 0; y < state.cells.length && y < bounds.leftSlant; y++) {
+          const oldOffset = HexGrid2D.getMinX(y, oldBounds.left);
+          const newOffset = HexGrid2D.getMinX(y, bounds.left);
+          const newMax = HexGrid2D.getMaxX(y, bounds.right, bounds.rightSlant);
+          const newWidth = newMax - newOffset + 1;
+          for (let i = 0; i < newWidth; i++) {
+            const x = newOffset + i;
+            const oldIdx = x - oldOffset;
+            if (oldIdx >= 0 && oldIdx < state.cells[y].length) {
+              newCells[y][i] = state.cells[y][oldIdx];
+            }
+          }
+        }
+        const isInBounds = (x: number, y: number): boolean => {
+          if (y < 0 || y >= bounds.leftSlant) return false;
+          const minX = HexGrid2D.getMinX(y, bounds.left);
+          const maxX = HexGrid2D.getMaxX(y, bounds.right, bounds.rightSlant);
+          return x >= minX && x <= maxX;
+        };
+        const filteredSpawns = state.spawns.filter((s) => isInBounds(s.x, s.y));
+        const filteredTrack = state.track.filter((c) => isInBounds(c.x, c.y));
+        return pushHistory(state, {
+          bounds,
+          cells: recomputeBombSiteIndices(newCells),
+          spawns: filteredSpawns,
+          track: filteredTrack,
+        });
+      });
+    },
+
+    setTool(tool) {
+      set({ tool });
+    },
+
+    paintCell(coord) {
+      set((state) => {
+        const cell = getCellAt(state, coord);
+        if (!cell) return state;
+
+        const { tool } = state;
+        let newCells = state.cells;
+        let newSpawns = state.spawns;
+        let newTrack = state.track;
+
+        const removeSpawnAt = (c: ICoordinate) =>
+          newSpawns.filter((s) => !(s.x === c.x && s.y === c.y));
+
+        switch (tool.kind) {
+          case "terrain": {
+            if (cell.terrain === tool.terrain) return state;
+            newCells = setCellAt(state, coord, {
+              terrain: tool.terrain,
+              troopCount: null,
+              siteIndex: null,
+            });
+            // If we changed a general/bombsite/etc, clean spawns/track
+            if (cell.terrain === T.GENERAL) newSpawns = removeSpawnAt(coord);
+            if (cell.terrain === T.BOMB_SITE)
+              newCells = recomputeBombSiteIndices(newCells);
+            break;
+          }
+          case "city": {
+            newCells = setCellAt(state, coord, {
+              terrain: T.CITY as Terrain,
+              troopCount: tool.troopCount,
+              siteIndex: null,
+            });
+            if (cell.terrain === T.GENERAL) newSpawns = removeSpawnAt(coord);
+            if (cell.terrain === T.BOMB_SITE)
+              newCells = recomputeBombSiteIndices(newCells);
+            break;
+          }
+          case "general": {
+            // Place general & spawn assignment
+            newCells = setCellAt(state, coord, {
+              terrain: T.GENERAL as Terrain,
+              troopCount: null,
+              siteIndex: null,
+            });
+            // Remove existing spawn at this position (replacing)
+            newSpawns = newSpawns.filter(
+              (s) => !(s.x === coord.x && s.y === coord.y),
+            );
+            // Remove any other spawn with same team+slot
+            newSpawns = newSpawns.filter(
+              (s) => !(s.teamId === tool.teamId && s.slot === tool.slot),
+            );
+            newSpawns = [
+              ...newSpawns,
+              {
+                x: coord.x,
+                y: coord.y,
+                teamId: tool.teamId,
+                slot: tool.slot,
+              },
+            ];
+            if (cell.terrain === T.BOMB_SITE)
+              newCells = recomputeBombSiteIndices(newCells);
+            break;
+          }
+          case "bombSite": {
+            newCells = setCellAt(state, coord, {
+              terrain: T.BOMB_SITE as Terrain,
+              troopCount: null,
+              siteIndex: 0,
+            });
+            if (cell.terrain === T.GENERAL) newSpawns = removeSpawnAt(coord);
+            newCells = recomputeBombSiteIndices(newCells);
+            break;
+          }
+          case "trackAdd": {
+            if (newTrack.some((c) => c.x === coord.x && c.y === coord.y)) {
+              return state;
+            }
+            newTrack = [...newTrack, { x: coord.x, y: coord.y }];
+            break;
+          }
+          case "trackRemove": {
+            newTrack = newTrack.filter(
+              (c) => !(c.x === coord.x && c.y === coord.y),
+            );
+            break;
+          }
+          case "erase": {
+            newCells = setCellAt(state, coord, {
+              terrain: T.PLAIN as Terrain,
+              troopCount: null,
+              siteIndex: null,
+            });
+            newSpawns = removeSpawnAt(coord);
+            newTrack = newTrack.filter(
+              (c) => !(c.x === coord.x && c.y === coord.y),
+            );
+            if (cell.terrain === T.BOMB_SITE)
+              newCells = recomputeBombSiteIndices(newCells);
+            break;
+          }
+        }
+
+        return pushHistory(state, {
+          cells: newCells,
+          spawns: newSpawns,
+          track: newTrack,
+        });
+      });
+    },
+
+    undo() {
+      set((state) => {
+        if (state.historyIndex < 0) return state;
+        const snapshot = state.history[state.historyIndex];
+        if (!snapshot) return state;
+        return {
+          ...state,
+          cells: snapshot.cells,
+          spawns: snapshot.spawns,
+          track: snapshot.track,
+          historyIndex: state.historyIndex - 1,
+        };
+      });
+    },
+
+    redo() {
+      set((state) => {
+        const next = state.historyIndex + 1;
+        const snapshot = state.history[next];
+        if (!snapshot) return state;
+        // Note: simple impl — redo replays the next snapshot
+        return {
+          ...state,
+          cells: snapshot.cells,
+          spawns: snapshot.spawns,
+          track: snapshot.track,
+          historyIndex: next,
+        };
+      });
+    },
+
+    setSaving(value) {
+      set({ saving: value });
+    },
+
+    setLastSavedAt(value) {
+      set({ lastSavedAt: value });
+    },
+
+    setSaveError(value) {
+      set({ saveError: value });
+    },
+
+    getTemplate(): GridTemplate {
+      const s = get();
+      return {
+        gridType: s.gridType,
+        bounds: s.bounds,
+        cells: s.cells,
+        spawns: s.spawns,
+        track: s.track.length > 0 ? s.track : undefined,
+      };
+    },
+  }),
+);

--- a/apps/client/src/features/map-editor/store/editor-store.ts
+++ b/apps/client/src/features/map-editor/store/editor-store.ts
@@ -378,7 +378,17 @@ export const useEditorStore = create<EditorState & EditorActions>(
             ];
             if (cell.terrain === T.BOMB_SITE)
               newCells = recomputeBombSiteIndices(newCells);
-            break;
+
+            // Auto increment slot for next placement
+            return pushHistory(state, {
+              cells: newCells,
+              spawns: newSpawns,
+              track: newTrack,
+              tool: {
+                ...tool,
+                slot: tool.slot + 1,
+              },
+            });
           }
           case "bombSite": {
             newCells = setCellAt(state, coord, {

--- a/apps/client/src/routes/map-editor.tsx
+++ b/apps/client/src/routes/map-editor.tsx
@@ -1,0 +1,5 @@
+import { MapEditorPage } from "#/features/map-editor/pages/map-editor-page";
+
+export default function MapEditorRoute() {
+  return <MapEditorPage />;
+}

--- a/apps/client/src/routes/maps.tsx
+++ b/apps/client/src/routes/maps.tsx
@@ -1,0 +1,5 @@
+import { MapBrowserPage } from "#/features/map-editor/pages/map-browser-page";
+
+export default function MapsRoute() {
+  return <MapBrowserPage />;
+}

--- a/apps/server/src/app.config.ts
+++ b/apps/server/src/app.config.ts
@@ -13,6 +13,7 @@ import mongoose from "mongoose";
 
 import { ENV } from "#/env";
 import { auth } from "#/features/auth/auth-config";
+import { registerMapRoutes } from "#/features/maps/map-routes";
 import { MatchRoom } from "#/features/match/match-room";
 import { registerProfileRoutes } from "#/features/profile/profile-routes";
 import { MatchQueueRoom } from "#/features/queue/queue-room";
@@ -100,6 +101,8 @@ export default defineServer({
     }
 
     registerCustomRoomRoutes(app);
+
+    registerMapRoutes(app);
 
     // Health check endpoint
     app.get("/health", (_req, res) => {

--- a/apps/server/src/features/maps/grid-serializer.ts
+++ b/apps/server/src/features/maps/grid-serializer.ts
@@ -1,0 +1,119 @@
+import type { Grid, ICoordinate } from "@generals-plus/engine";
+import {
+  Cell,
+  GridType,
+  HexGrid,
+  HexGrid2D,
+  SquareGrid,
+} from "@generals-plus/engine";
+
+import type {
+  CellTemplate,
+  GridTemplate,
+  SpawnPoint,
+} from "#/infra/db/models/map-model";
+
+export function createGridFromDoc(gridDoc: GridTemplate): Grid {
+  const { gridType, cells, track } = gridDoc;
+  const bounds = gridDoc.bounds;
+
+  if (gridType === GridType.SQUARE) {
+    const { width, height } = bounds as { width: number; height: number };
+    const cellObjects = cells.map((row, y) =>
+      row.map(
+        (c, x) =>
+          new Cell({
+            coordinate: { x, y },
+            terrain: c.terrain,
+            troopCount: c.troopCount,
+            siteIndex: c.siteIndex,
+          }),
+      ),
+    );
+    const grid = new SquareGrid(width, height, cellObjects);
+    if (track && track.length > 0) {
+      grid.track = track;
+    }
+    return grid;
+  }
+
+  const { left, right, leftSlant, rightSlant } = bounds as {
+    left: number;
+    right: number;
+    leftSlant: number;
+    rightSlant: number;
+  };
+  const cellObjects = cells.map((row, y) => {
+    const minX = HexGrid2D.getMinX(y, left);
+    return row.map(
+      (c, i) =>
+        new Cell({
+          coordinate: { x: minX + i, y },
+          terrain: c.terrain,
+          troopCount: c.troopCount,
+          siteIndex: c.siteIndex,
+        }),
+    );
+  });
+  const grid = new HexGrid(left, right, leftSlant, rightSlant, cellObjects);
+  if (track && track.length > 0) {
+    grid.track = track;
+  }
+  return grid;
+}
+
+export function buildSpawnMap(
+  spawns: SpawnPoint[],
+  teamAssignments: Record<string, string>,
+  playerIds: string[],
+): Map<string, ICoordinate> {
+  const teamPlayers = new Map<string, string[]>();
+  for (const playerId of playerIds) {
+    const teamId = teamAssignments[playerId];
+    if (!teamId) continue;
+    if (!teamPlayers.has(teamId)) teamPlayers.set(teamId, []);
+    teamPlayers.get(teamId)?.push(playerId);
+  }
+
+  const result = new Map<string, ICoordinate>();
+  for (const spawn of spawns) {
+    const players = teamPlayers.get(spawn.teamId) ?? [];
+    const player = players[spawn.slot];
+    if (player) {
+      result.set(player, { x: spawn.x, y: spawn.y });
+    }
+  }
+  return result;
+}
+
+export function serializeGrid(grid: Grid, spawns: SpawnPoint[]): GridTemplate {
+  const cells: CellTemplate[][] = [];
+  grid.forEach((cell) => {
+    const y = cell.coordinate.y;
+    if (!cells[y]) cells[y] = [];
+    cells[y].push({
+      terrain: cell.terrain,
+      troopCount: cell.troopCount,
+      siteIndex: cell.siteIndex,
+    });
+  });
+
+  const bounds =
+    grid.gridType === GridType.SQUARE
+      ? { width: grid.width, height: grid.height }
+      : {
+          left: grid.left,
+          right: grid.right,
+          leftSlant: grid.leftSlant,
+          rightSlant: grid.rightSlant,
+        };
+
+  return {
+    gridType: grid.gridType,
+    bounds,
+    cells,
+    track:
+      grid.track.length > 0 ? grid.track.map((c) => ({ ...c })) : undefined,
+    spawns,
+  };
+}

--- a/apps/server/src/features/maps/map-routes.ts
+++ b/apps/server/src/features/maps/map-routes.ts
@@ -201,11 +201,15 @@ export function registerMapRoutes(app: {
       return;
     }
 
+    const id = getParam(request.params, "id");
+    const map = await mapRepository.findById(id);
+    if (!map) {
+      response.status(404).json({ error: "Map not found" });
+      return;
+    }
+
     try {
-      const result = await mapRepository.toggleLike(
-        getParam(request.params, "id"),
-        userId,
-      );
+      const result = await mapRepository.toggleLike(id, userId);
       response.json({ result });
     } catch (_error) {
       response.status(500).json({ error: "Failed to toggle like" });

--- a/apps/server/src/features/maps/map-routes.ts
+++ b/apps/server/src/features/maps/map-routes.ts
@@ -1,0 +1,214 @@
+import { JWT } from "@colyseus/auth";
+import type { GameMode } from "@generals-plus/engine";
+import type { Request, Response } from "express";
+
+import { createMapSchema, updateMapSchema } from "#/features/maps/schemas";
+import { validateMapGrid } from "#/features/maps/validate-map";
+import { MongoMapRepository } from "#/infra/db/repositories/MongoMapRepository";
+
+const mapRepository = new MongoMapRepository();
+
+function getParam(
+  params: Record<string, string | string[]>,
+  key: string,
+): string {
+  const value = params[key];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function getAuthorizedUserId(request: Request) {
+  const header = request.header("authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  const token = header.slice("Bearer ".length).trim();
+  if (!token) return null;
+
+  try {
+    const auth = (await JWT.verify(token)) as { id?: string } | null;
+    return auth?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function getAuthorizedUser(request: Request) {
+  const header = request.header("authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  const token = header.slice("Bearer ".length).trim();
+  if (!token) return null;
+
+  try {
+    const auth = (await JWT.verify(token)) as {
+      id?: string;
+      displayName?: string;
+    } | null;
+    if (!auth?.id) return null;
+    return { id: auth.id, displayName: auth.displayName ?? "Anonymous" };
+  } catch {
+    return null;
+  }
+}
+
+export function registerMapRoutes(app: {
+  get: (
+    path: string,
+    handler: (req: Request, res: Response) => Promise<void>,
+  ) => void;
+  post: (
+    path: string,
+    handler: (req: Request, res: Response) => Promise<void>,
+  ) => void;
+  put: (
+    path: string,
+    handler: (req: Request, res: Response) => Promise<void>,
+  ) => void;
+  delete: (
+    path: string,
+    handler: (req: Request, res: Response) => Promise<void>,
+  ) => void;
+}) {
+  // List published maps
+  app.get("/api/maps", async (request, response) => {
+    const page = Math.max(1, Number(request.query.page) || 1);
+    const limit = Math.min(50, Math.max(1, Number(request.query.limit) || 20));
+    const mode = request.query.mode as GameMode | undefined;
+    const sort = request.query.sort as "plays" | "likes" | "date" | undefined;
+
+    try {
+      const result = await mapRepository.findPublished({
+        page,
+        limit,
+        mode,
+        sort,
+      });
+      response.json(result);
+    } catch (_error) {
+      response.status(500).json({ error: "Failed to fetch maps" });
+    }
+  });
+
+  // Get single map
+  app.get("/api/maps/:id", async (request, response) => {
+    const map = await mapRepository.findById(getParam(request.params, "id"));
+    if (!map) {
+      response.status(404).json({ error: "Map not found" });
+      return;
+    }
+    response.json(map);
+  });
+
+  // Create map
+  app.post("/api/maps", async (request, response) => {
+    const user = await getAuthorizedUser(request);
+    if (!user) {
+      response.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const result = createMapSchema.safeParse(request.body);
+    if (!result.success) {
+      response
+        .status(400)
+        .json({ error: "Validation failed", details: result.error.issues });
+      return;
+    }
+
+    const data = result.data;
+
+    // Validate grid structure and connectivity
+    const gridValidation = validateMapGrid(data.grid);
+    if (!gridValidation.valid) {
+      response
+        .status(400)
+        .json({ error: "Invalid grid", details: gridValidation.errors });
+      return;
+    }
+
+    try {
+      const map = await mapRepository.create(user.id, user.displayName, data);
+      response.status(201).json(map);
+    } catch (_error) {
+      response.status(500).json({ error: "Failed to create map" });
+    }
+  });
+
+  // Update map
+  app.put("/api/maps/:id", async (request, response) => {
+    const userId = await getAuthorizedUserId(request);
+    if (!userId) {
+      response.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const result = updateMapSchema.safeParse(request.body);
+    if (!result.success) {
+      response
+        .status(400)
+        .json({ error: "Validation failed", details: result.error.issues });
+      return;
+    }
+
+    // If grid is being updated, validate it
+    if (result.data.grid) {
+      const gridValidation = validateMapGrid(result.data.grid);
+      if (!gridValidation.valid) {
+        response
+          .status(400)
+          .json({ error: "Invalid grid", details: gridValidation.errors });
+        return;
+      }
+    }
+
+    try {
+      const map = await mapRepository.update(
+        getParam(request.params, "id"),
+        userId,
+        result.data,
+      );
+      if (!map) {
+        response.status(404).json({ error: "Map not found or not authorized" });
+        return;
+      }
+      response.json(map);
+    } catch (_error) {
+      response.status(500).json({ error: "Failed to update map" });
+    }
+  });
+
+  // Delete map
+  app.delete("/api/maps/:id", async (request, response) => {
+    const userId = await getAuthorizedUserId(request);
+    if (!userId) {
+      response.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const deleted = await mapRepository.delete(
+      getParam(request.params, "id"),
+      userId,
+    );
+    if (!deleted) {
+      response.status(404).json({ error: "Map not found or not authorized" });
+      return;
+    }
+    response.status(204).end();
+  });
+
+  // Toggle like
+  app.post("/api/maps/:id/like", async (request, response) => {
+    const userId = await getAuthorizedUserId(request);
+    if (!userId) {
+      response.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    try {
+      const result = await mapRepository.toggleLike(
+        getParam(request.params, "id"),
+        userId,
+      );
+      response.json({ result });
+    } catch (_error) {
+      response.status(500).json({ error: "Failed to toggle like" });
+    }
+  });
+}

--- a/apps/server/src/features/maps/schemas.ts
+++ b/apps/server/src/features/maps/schemas.ts
@@ -1,0 +1,78 @@
+import { GameMode, GridType, Terrain } from "@generals-plus/engine";
+import * as z from "zod";
+
+const TerrainSchema = z.enum(Terrain);
+
+const CellTemplateSchema = z.object({
+  terrain: TerrainSchema,
+  troopCount: z.number().nullable().default(null),
+  siteIndex: z.number().int().min(0).nullable().default(null),
+});
+
+const SpawnPointSchema = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  teamId: z.string().min(1),
+  slot: z.number().int().min(0),
+});
+
+const CoordinateSchema = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+});
+
+const SquareBoundsSchema = z.object({
+  width: z.number().int().min(5).max(100),
+  height: z.number().int().min(5).max(100),
+});
+
+const HexBoundsSchema = z.object({
+  left: z.number().int().min(1),
+  right: z.number().int().min(1),
+  leftSlant: z.number().int().min(3),
+  rightSlant: z.number().int().min(3),
+});
+
+const GridTemplateSchema = z.discriminatedUnion("gridType", [
+  z.object({
+    gridType: z.literal(GridType.SQUARE),
+    bounds: SquareBoundsSchema,
+    cells: z.array(z.array(CellTemplateSchema)),
+    track: z.array(CoordinateSchema).optional(),
+    spawns: z.array(SpawnPointSchema),
+  }),
+  z.object({
+    gridType: z.literal(GridType.HEX),
+    bounds: HexBoundsSchema,
+    cells: z.array(z.array(CellTemplateSchema)),
+    track: z.array(CoordinateSchema).optional(),
+    spawns: z.array(SpawnPointSchema),
+  }),
+]);
+
+export const createMapSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(1000).optional(),
+  grid: GridTemplateSchema,
+  supportedModes: z.array(z.enum(GameMode)).min(1),
+  minPlayers: z.number().int().min(2),
+  maxPlayers: z.number().int().min(2),
+  tags: z.array(z.string()).optional(),
+  status: z.enum(["draft", "published"]).optional(),
+  thumbnail: z.string().optional(),
+});
+
+export const updateMapSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  description: z.string().max(1000).optional(),
+  grid: GridTemplateSchema.optional(),
+  supportedModes: z.array(z.enum(GameMode)).min(1).optional(),
+  minPlayers: z.number().int().min(2).optional(),
+  maxPlayers: z.number().int().min(2).optional(),
+  tags: z.array(z.string()).optional(),
+  status: z.enum(["draft", "published"]).optional(),
+  thumbnail: z.string().optional(),
+});
+
+export type CreateMapInput = z.infer<typeof createMapSchema>;
+export type UpdateMapInput = z.infer<typeof updateMapSchema>;

--- a/apps/server/src/features/maps/validate-map.ts
+++ b/apps/server/src/features/maps/validate-map.ts
@@ -1,0 +1,149 @@
+import { Terrain } from "@generals-plus/engine";
+
+import type { GridTemplate } from "#/infra/db/models/map-model";
+
+export interface MapValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export function validateMapGrid(grid: GridTemplate): MapValidationResult {
+  const errors: string[] = [];
+  const { gridType, bounds, cells, spawns } = grid;
+  const boundsRecord = bounds as unknown as Record<string, number>;
+
+  // Validate cells dimensions
+  if (gridType === "square") {
+    const { width, height } = boundsRecord;
+    if (cells.length !== height) {
+      errors.push(`Expected ${height} rows, got ${cells.length}`);
+    }
+    for (let y = 0; y < cells.length; y++) {
+      if (cells[y].length !== width) {
+        errors.push(
+          `Row ${y}: expected ${width} cells, got ${cells[y].length}`,
+        );
+      }
+    }
+  } else {
+    const { left, right, leftSlant, rightSlant } = boundsRecord;
+    if (cells.length !== leftSlant) {
+      errors.push(`Expected ${leftSlant} rows, got ${cells.length}`);
+    }
+    for (let y = 0; y < cells.length; y++) {
+      const minX = Math.max(-left + 1, -y);
+      const maxX = Math.min(right - 1, rightSlant - y - 1);
+      const expected = maxX - minX + 1;
+      if (cells[y].length !== expected) {
+        errors.push(
+          `Row ${y}: expected ${expected} cells, got ${cells[y].length}`,
+        );
+      }
+    }
+  }
+
+  // Count generals
+  const generalCoords: { x: number; y: number }[] = [];
+  let _flagCount = 0;
+  let _bombSiteCount = 0;
+
+  for (let y = 0; y < cells.length; y++) {
+    for (let x = 0; x < cells[y].length; x++) {
+      const cell = cells[y][x];
+      if (cell.terrain === Terrain.GENERAL) {
+        generalCoords.push({ x, y });
+      }
+      if (cell.terrain === Terrain.FLAG) _flagCount++;
+      if (cell.terrain === Terrain.BOMB_SITE) _bombSiteCount++;
+    }
+  }
+
+  if (generalCoords.length < 2) {
+    errors.push("Map must have at least 2 generals");
+  }
+
+  // Validate spawns
+  if (spawns.length < 2) {
+    errors.push("Map must have at least 2 spawn points");
+  }
+
+  const spawnKeys = new Set<string>();
+  for (const spawn of spawns) {
+    const key = `${spawn.teamId}:${spawn.slot}`;
+    if (spawnKeys.has(key)) {
+      errors.push(`Duplicate spawn: team ${spawn.teamId} slot ${spawn.slot}`);
+    }
+    spawnKeys.add(key);
+
+    // Check spawn coordinate is a general cell
+    const row = cells[spawn.y];
+    if (!row || spawn.x >= row.length) {
+      errors.push(`Spawn at (${spawn.x}, ${spawn.y}) is out of bounds`);
+    } else if (row[spawn.x].terrain !== Terrain.GENERAL) {
+      errors.push(`Spawn at (${spawn.x}, ${spawn.y}) is not on a general cell`);
+    }
+  }
+
+  // Check spawn count matches general count
+  if (spawns.length !== generalCoords.length) {
+    errors.push(
+      `Spawn count (${spawns.length}) does not match general count (${generalCoords.length})`,
+    );
+  }
+
+  // Validate connectivity between generals
+  if (generalCoords.length >= 2) {
+    if (!checkGeneralConnectivity(cells, generalCoords)) {
+      errors.push("Not all generals are reachable from each other");
+    }
+  }
+
+  // Mode-specific checks are done at the route level using supportedModes
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+function checkGeneralConnectivity(
+  cells: { terrain: string }[][],
+  generalCoords: { x: number; y: number }[],
+): boolean {
+  const height = cells.length;
+  const passable = (x: number, y: number): boolean => {
+    if (y < 0 || y >= height) return false;
+    const row = cells[y];
+    if (!row || x < 0 || x >= row.length) return false;
+    const t = row[x].terrain;
+    return t !== Terrain.MOUNTAIN && t !== Terrain.VOID;
+  };
+
+  // BFS from first general
+  const start = generalCoords[0];
+  const visited = new Set<string>();
+  const queue = [start];
+  visited.add(`${start.x},${start.y}`);
+
+  while (queue.length > 0) {
+    const head = queue.shift();
+    if (!head) break;
+    const { x, y } = head;
+    for (const [dx, dy] of [
+      [0, 1],
+      [0, -1],
+      [1, 0],
+      [-1, 0],
+    ]) {
+      const nx = x + dx;
+      const ny = y + dy;
+      const key = `${nx},${ny}`;
+      if (!visited.has(key) && passable(nx, ny)) {
+        visited.add(key);
+        queue.push({ x: nx, y: ny });
+      }
+    }
+  }
+
+  return generalCoords.every((g) => visited.has(`${g.x},${g.y}`));
+}

--- a/apps/server/src/features/maps/validate-map.ts
+++ b/apps/server/src/features/maps/validate-map.ts
@@ -7,6 +7,27 @@ export interface MapValidationResult {
   errors: string[];
 }
 
+const getMinX = (gridType: string, bounds: any, y: number): number => {
+  if (gridType === "square") return 0;
+  const { left } = bounds as unknown as { left: number };
+  return Math.max(-left + 1, -y);
+};
+
+const getCell = (
+  gridType: string,
+  bounds: any,
+  cells: { terrain: string }[][],
+  x: number,
+  y: number,
+) => {
+  if (y < 0 || y >= cells.length) return null;
+  const row = cells[y];
+  if (!row) return null;
+  const minX = getMinX(gridType, bounds, y);
+  const idx = x - minX;
+  return row[idx] ?? null;
+};
+
 export function validateMapGrid(grid: GridTemplate): MapValidationResult {
   const errors: string[] = [];
   const { gridType, bounds, cells, spawns } = grid;
@@ -42,14 +63,16 @@ export function validateMapGrid(grid: GridTemplate): MapValidationResult {
     }
   }
 
-  // Count generals
+  // Count generals (using absolute coordinates)
   const generalCoords: { x: number; y: number }[] = [];
   let _flagCount = 0;
   let _bombSiteCount = 0;
 
   for (let y = 0; y < cells.length; y++) {
-    for (let x = 0; x < cells[y].length; x++) {
-      const cell = cells[y][x];
+    const minX = getMinX(gridType, bounds, y);
+    for (let idx = 0; idx < cells[y].length; idx++) {
+      const cell = cells[y][idx];
+      const x = minX + idx; // absolute x coordinate
       if (cell.terrain === Terrain.GENERAL) {
         generalCoords.push({ x, y });
       }
@@ -76,10 +99,10 @@ export function validateMapGrid(grid: GridTemplate): MapValidationResult {
     spawnKeys.add(key);
 
     // Check spawn coordinate is a general cell
-    const row = cells[spawn.y];
-    if (!row || spawn.x >= row.length) {
+    const cell = getCell(gridType, bounds, cells, spawn.x, spawn.y);
+    if (!cell) {
       errors.push(`Spawn at (${spawn.x}, ${spawn.y}) is out of bounds`);
-    } else if (row[spawn.x].terrain !== Terrain.GENERAL) {
+    } else if (cell.terrain !== Terrain.GENERAL) {
       errors.push(`Spawn at (${spawn.x}, ${spawn.y}) is not on a general cell`);
     }
   }
@@ -93,7 +116,7 @@ export function validateMapGrid(grid: GridTemplate): MapValidationResult {
 
   // Validate connectivity between generals
   if (generalCoords.length >= 2) {
-    if (!checkGeneralConnectivity(cells, generalCoords)) {
+    if (!checkGeneralConnectivity(gridType, bounds, cells, generalCoords)) {
       errors.push("Not all generals are reachable from each other");
     }
   }
@@ -107,16 +130,15 @@ export function validateMapGrid(grid: GridTemplate): MapValidationResult {
 }
 
 function checkGeneralConnectivity(
+  gridType: string,
+  bounds: any,
   cells: { terrain: string }[][],
   generalCoords: { x: number; y: number }[],
 ): boolean {
-  const height = cells.length;
   const passable = (x: number, y: number): boolean => {
-    if (y < 0 || y >= height) return false;
-    const row = cells[y];
-    if (!row || x < 0 || x >= row.length) return false;
-    const t = row[x].terrain;
-    return t !== Terrain.MOUNTAIN && t !== Terrain.VOID;
+    const cell = getCell(gridType, bounds, cells, x, y);
+    if (!cell) return false;
+    return cell.terrain !== Terrain.MOUNTAIN && cell.terrain !== Terrain.VOID;
   };
 
   // BFS from first general
@@ -125,16 +147,28 @@ function checkGeneralConnectivity(
   const queue = [start];
   visited.add(`${start.x},${start.y}`);
 
+  const offsets =
+    gridType === "square"
+      ? [
+          [0, -1],
+          [1, 0],
+          [0, 1],
+          [-1, 0],
+        ]
+      : [
+          [0, -1],
+          [1, -1],
+          [1, 0],
+          [0, 1],
+          [-1, 1],
+          [-1, 0],
+        ];
+
   while (queue.length > 0) {
     const head = queue.shift();
     if (!head) break;
     const { x, y } = head;
-    for (const [dx, dy] of [
-      [0, 1],
-      [0, -1],
-      [1, 0],
-      [-1, 0],
-    ]) {
+    for (const [dx, dy] of offsets) {
       const nx = x + dx;
       const ny = y + dy;
       const key = `${nx},${ny}`;

--- a/apps/server/src/features/maps/validate-map.ts
+++ b/apps/server/src/features/maps/validate-map.ts
@@ -74,8 +74,6 @@ export function validateMapGrid(grid: GridTemplate): MapValidationResult {
 
   // Count generals (using absolute coordinates)
   const generalCoords: { x: number; y: number }[] = [];
-  let _flagCount = 0;
-  let _bombSiteCount = 0;
 
   for (let y = 0; y < cells.length; y++) {
     const minX = getMinX(gridType, bounds, y);
@@ -85,8 +83,6 @@ export function validateMapGrid(grid: GridTemplate): MapValidationResult {
       if (cell.terrain === Terrain.GENERAL) {
         generalCoords.push({ x, y });
       }
-      if (cell.terrain === Terrain.FLAG) _flagCount++;
-      if (cell.terrain === Terrain.BOMB_SITE) _bombSiteCount++;
     }
   }
 

--- a/apps/server/src/features/maps/validate-map.ts
+++ b/apps/server/src/features/maps/validate-map.ts
@@ -1,4 +1,9 @@
 import { Terrain } from "@generals-plus/engine";
+import type {
+  CellTemplate,
+  HexGridBounds,
+  SquareGridBounds,
+} from "@generals-plus/shared-types";
 
 import type { GridTemplate } from "#/infra/db/models/map-model";
 
@@ -7,16 +12,20 @@ export interface MapValidationResult {
   errors: string[];
 }
 
-const getMinX = (gridType: string, bounds: any, y: number): number => {
+const getMinX = (
+  gridType: string,
+  bounds: SquareGridBounds | HexGridBounds,
+  y: number,
+): number => {
   if (gridType === "square") return 0;
-  const { left } = bounds as unknown as { left: number };
+  const { left } = bounds as HexGridBounds;
   return Math.max(-left + 1, -y);
 };
 
 const getCell = (
   gridType: string,
-  bounds: any,
-  cells: { terrain: string }[][],
+  bounds: SquareGridBounds | HexGridBounds,
+  cells: CellTemplate[][],
   x: number,
   y: number,
 ) => {
@@ -131,8 +140,8 @@ export function validateMapGrid(grid: GridTemplate): MapValidationResult {
 
 function checkGeneralConnectivity(
   gridType: string,
-  bounds: any,
-  cells: { terrain: string }[][],
+  bounds: SquareGridBounds | HexGridBounds,
+  cells: CellTemplate[][],
   generalCoords: { x: number; y: number }[],
 ): boolean {
   const passable = (x: number, y: number): boolean => {

--- a/apps/server/src/features/setup/schemas.ts
+++ b/apps/server/src/features/setup/schemas.ts
@@ -9,6 +9,8 @@ export const setupSettingsUpdateSchema = z
     isPublic: z.boolean(),
     playersPerTeam: z.number().int().min(1),
     mapType: z.enum(GridType),
+    mapSource: z.enum(["generated", "custom"]),
+    customMapId: z.string(),
     mapWidth: z.number().int().min(5).max(100),
     mapHeight: z.number().int().min(5).max(100),
     mapLeft: z.number().int().min(5).max(100),

--- a/apps/server/src/features/setup/setup-room.ts
+++ b/apps/server/src/features/setup/setup-room.ts
@@ -832,6 +832,8 @@ export class SetupRoom extends Room<{ state: SetupState }> {
         throw new Error(`Custom map "${this.state.customMapId}" not found`);
       }
 
+      await mapRepository.incrementPlays(this.state.customMapId);
+
       const grid = createGridFromDoc(mapDoc.grid);
       const teamAssignments = this.buildFinalTeamAssignments();
       const spawnMap = buildSpawnMap(

--- a/apps/server/src/features/setup/setup-room.ts
+++ b/apps/server/src/features/setup/setup-room.ts
@@ -1,7 +1,11 @@
 import { JWT } from "@colyseus/auth";
 import type { Client } from "@colyseus/core";
 import { logger, matchMaker, Room } from "@colyseus/core";
-import type { CollapseShape, GridGeneratorInput } from "@generals-plus/engine";
+import type {
+  CollapseShape,
+  GridGeneratorInput,
+  GridInput,
+} from "@generals-plus/engine";
 import {
   DefaultGenOptions,
   DefaultGridBounds,
@@ -29,6 +33,10 @@ import {
 import type { CreateGameOptions } from "#/features/game/utils";
 import { createGame, generateSeed } from "#/features/game/utils";
 import {
+  buildSpawnMap,
+  createGridFromDoc,
+} from "#/features/maps/grid-serializer";
+import {
   BASE_TICK_INTERVAL,
   calculateFinishTick,
   MODE_SETTINGS,
@@ -39,6 +47,7 @@ import {
   onSetupRoomDisposed,
 } from "#/features/setup/custom-room-registry";
 import { setupSettingsUpdateSchema } from "#/features/setup/schemas";
+import { MongoMapRepository } from "#/infra/db/repositories/MongoMapRepository";
 
 const DEFAULT_MAX_PLAYERS = 8;
 const SETUP_TEAM_PREFIX = "setup_team_";
@@ -729,10 +738,13 @@ export class SetupRoom extends Room<{ state: SetupState }> {
     return base;
   }
 
-  private buildCreateGameOptions(): CreateGameOptions {
+  private buildCreateGameOptions(customGrid?: {
+    gridOptions: GridInput;
+    spawnMap?: Map<string, import("@generals-plus/engine").ICoordinate>;
+  }): CreateGameOptions {
     const teamAssignments = this.buildFinalTeamAssignments();
     const base = {
-      gridOptions: this.getGridOptions(),
+      gridOptions: customGrid?.gridOptions ?? this.getGridOptions(),
       playerIds: this.state.players.map((p) => p.id),
       playerPerTeam: this.state.playersPerTeam,
       teamAssignments,
@@ -806,8 +818,40 @@ export class SetupRoom extends Room<{ state: SetupState }> {
   }
 
   private async startGame() {
-    const options = this.buildCreateGameOptions();
+    let customGrid:
+      | {
+          gridOptions: GridInput;
+          spawnMap?: Map<string, import("@generals-plus/engine").ICoordinate>;
+        }
+      | undefined;
+
+    if (this.state.mapSource === "custom" && this.state.customMapId) {
+      const mapRepository = new MongoMapRepository();
+      const mapDoc = await mapRepository.findById(this.state.customMapId);
+      if (!mapDoc) {
+        throw new Error(`Custom map "${this.state.customMapId}" not found`);
+      }
+
+      const grid = createGridFromDoc(mapDoc.grid);
+      const teamAssignments = this.buildFinalTeamAssignments();
+      const spawnMap = buildSpawnMap(
+        mapDoc.grid.spawns,
+        teamAssignments,
+        this.state.players.map((p) => p.id),
+      );
+
+      customGrid = {
+        gridOptions: { grid },
+        spawnMap: spawnMap.size > 0 ? spawnMap : undefined,
+      };
+    }
+
+    const options = this.buildCreateGameOptions(customGrid);
     const game = createGame(options);
+
+    if (customGrid?.spawnMap) {
+      game.spawnPositions = customGrid.spawnMap;
+    }
 
     const playerInit = createPlayerInit(this.state.players, game);
 

--- a/apps/server/src/infra/db/interfaces.ts
+++ b/apps/server/src/infra/db/interfaces.ts
@@ -1,6 +1,7 @@
 import type { GameMode } from "@generals-plus/engine";
 import type { UserPreferences } from "@generals-plus/shared-types";
 
+import type { IMapDocument } from "#/infra/db/models/map-model";
 import type { IPlayerRatings } from "#/infra/db/models/user-model";
 
 /**
@@ -49,4 +50,70 @@ export interface IUserRepository {
   updateRatings(
     updates: Array<{ userId: string; mode: GameMode; newRating: number }>,
   ): Promise<void>;
+}
+
+export interface IMap {
+  id: string;
+  name: string;
+  description: string;
+  authorId: string;
+  authorName: string;
+  grid: IMapDocument["grid"];
+  supportedModes: GameMode[];
+  minPlayers: number;
+  maxPlayers: number;
+  tags: string[];
+  status: "draft" | "published";
+  stats: { plays: number; likes: number };
+  thumbnail: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface MapCreateOptions {
+  name: string;
+  description?: string;
+  grid: IMapDocument["grid"];
+  supportedModes: GameMode[];
+  minPlayers: number;
+  maxPlayers: number;
+  tags?: string[];
+  status?: "draft" | "published";
+  thumbnail?: string;
+}
+
+export interface MapUpdateOptions {
+  name?: string;
+  description?: string;
+  grid?: IMapDocument["grid"];
+  supportedModes?: GameMode[];
+  minPlayers?: number;
+  maxPlayers?: number;
+  tags?: string[];
+  status?: "draft" | "published";
+  thumbnail?: string;
+}
+
+export interface IMapRepository {
+  create(
+    authorId: string,
+    authorName: string,
+    options: MapCreateOptions,
+  ): Promise<IMap>;
+  findById(id: string): Promise<IMap | null>;
+  findByAuthor(authorId: string): Promise<IMap[]>;
+  findPublished(options: {
+    page?: number;
+    limit?: number;
+    mode?: GameMode;
+    sort?: "plays" | "likes" | "date";
+  }): Promise<{ maps: IMap[]; total: number }>;
+  update(
+    id: string,
+    authorId: string,
+    update: MapUpdateOptions,
+  ): Promise<IMap | null>;
+  delete(id: string, authorId: string): Promise<boolean>;
+  incrementPlays(id: string): Promise<void>;
+  toggleLike(id: string, userId: string): Promise<"liked" | "unliked">;
 }

--- a/apps/server/src/infra/db/models/like-model.ts
+++ b/apps/server/src/infra/db/models/like-model.ts
@@ -1,0 +1,19 @@
+import type { Document } from "mongoose";
+import mongoose, { Schema } from "mongoose";
+
+export interface ILikeDocument extends Document {
+  mapId: string;
+  userId: string;
+}
+
+const LikeSchema = new Schema<ILikeDocument>(
+  {
+    mapId: { type: String, required: true },
+    userId: { type: String, required: true },
+  },
+  { timestamps: true },
+);
+
+LikeSchema.index({ mapId: 1, userId: 1 }, { unique: true });
+
+export const LikeModel = mongoose.model<ILikeDocument>("Like", LikeSchema);

--- a/apps/server/src/infra/db/models/map-model.ts
+++ b/apps/server/src/infra/db/models/map-model.ts
@@ -1,0 +1,101 @@
+import type { GameMode } from "@generals-plus/engine";
+import type {
+  CellTemplate,
+  GridTemplate,
+  SpawnPoint,
+} from "@generals-plus/shared-types";
+import type { Document } from "mongoose";
+import mongoose, { Schema } from "mongoose";
+
+export type { CellTemplate, GridTemplate, SpawnPoint };
+
+export interface IMapDocument extends Document {
+  name: string;
+  description: string;
+  authorId: string;
+  authorName: string;
+  grid: GridTemplate;
+  supportedModes: GameMode[];
+  minPlayers: number;
+  maxPlayers: number;
+  tags: string[];
+  status: "draft" | "published";
+  stats: {
+    plays: number;
+    likes: number;
+  };
+  thumbnail: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const CellTemplateSchema = new Schema<CellTemplate>(
+  {
+    terrain: { type: String, required: true },
+    troopCount: { type: Number, default: null },
+    siteIndex: { type: Number, default: null },
+  },
+  { _id: false },
+);
+
+const SpawnPointSchema = new Schema<SpawnPoint>(
+  {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+    teamId: { type: String, required: true },
+    slot: { type: Number, required: true, min: 0 },
+  },
+  { _id: false },
+);
+
+const CoordinateSchema = new Schema(
+  {
+    x: { type: Number, required: true },
+    y: { type: Number, required: true },
+  },
+  { _id: false },
+);
+
+const GridTemplateSchema = new Schema<GridTemplate>(
+  {
+    gridType: { type: String, required: true, enum: ["square", "hex"] },
+    bounds: { type: Schema.Types.Mixed, required: true },
+    cells: { type: [[CellTemplateSchema]], required: true },
+    track: { type: [CoordinateSchema] },
+    spawns: { type: [SpawnPointSchema], required: true },
+  },
+  { _id: false },
+);
+
+const MapSchema = new Schema<IMapDocument>(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      minlength: 1,
+      maxlength: 100,
+    },
+    description: { type: String, default: "", maxlength: 1000 },
+    authorId: { type: String, required: true, index: true },
+    authorName: { type: String, required: true },
+    grid: { type: GridTemplateSchema, required: true },
+    supportedModes: { type: [String], required: true },
+    minPlayers: { type: Number, required: true, min: 2 },
+    maxPlayers: { type: Number, required: true, min: 2 },
+    tags: { type: [String], default: [] },
+    status: { type: String, enum: ["draft", "published"], default: "draft" },
+    stats: {
+      plays: { type: Number, default: 0 },
+      likes: { type: Number, default: 0 },
+    },
+    thumbnail: { type: String, default: "" },
+  },
+  { timestamps: true },
+);
+
+MapSchema.index({ status: 1, "stats.plays": -1 });
+MapSchema.index({ status: 1, "stats.likes": -1 });
+MapSchema.index({ status: 1, updatedAt: -1 });
+
+export const MapModel = mongoose.model<IMapDocument>("Map", MapSchema);

--- a/apps/server/src/infra/db/repositories/MongoMapRepository.ts
+++ b/apps/server/src/infra/db/repositories/MongoMapRepository.ts
@@ -1,0 +1,136 @@
+import type { GameMode } from "@generals-plus/engine";
+
+import type {
+  IMap,
+  IMapRepository,
+  MapCreateOptions,
+  MapUpdateOptions,
+} from "#/infra/db/interfaces";
+import type { IMapDocument } from "#/infra/db/models/map-model";
+import { MapModel } from "#/infra/db/models/map-model";
+
+export class MongoMapRepository implements IMapRepository {
+  private mapToEntity(doc: IMapDocument): IMap {
+    return {
+      id: doc._id.toString(),
+      name: doc.name,
+      description: doc.description,
+      authorId: doc.authorId,
+      authorName: doc.authorName,
+      grid: doc.grid,
+      supportedModes: doc.supportedModes,
+      minPlayers: doc.minPlayers,
+      maxPlayers: doc.maxPlayers,
+      tags: doc.tags,
+      status: doc.status,
+      stats: doc.stats,
+      thumbnail: doc.thumbnail,
+      createdAt: doc.createdAt,
+      updatedAt: doc.updatedAt,
+    };
+  }
+
+  async create(
+    authorId: string,
+    authorName: string,
+    options: MapCreateOptions,
+  ): Promise<IMap> {
+    const map = new MapModel({
+      ...options,
+      authorId,
+      authorName,
+      description: options.description ?? "",
+      tags: options.tags ?? [],
+      status: options.status ?? "draft",
+      thumbnail: options.thumbnail ?? "",
+    });
+    const saved = await map.save();
+    return this.mapToEntity(saved);
+  }
+
+  async findById(id: string): Promise<IMap | null> {
+    const map = await MapModel.findById(id).exec();
+    return map ? this.mapToEntity(map) : null;
+  }
+
+  async findByAuthor(authorId: string): Promise<IMap[]> {
+    const maps = await MapModel.find({ authorId })
+      .sort({ updatedAt: -1 })
+      .exec();
+    return maps.map((m) => this.mapToEntity(m));
+  }
+
+  async findPublished(options: {
+    page?: number;
+    limit?: number;
+    mode?: GameMode;
+    sort?: "plays" | "likes" | "date";
+  }): Promise<{ maps: IMap[]; total: number }> {
+    const page = Math.max(1, options.page ?? 1);
+    const limit = Math.min(50, Math.max(1, options.limit ?? 20));
+    const skip = (page - 1) * limit;
+
+    const filter: Record<string, unknown> = { status: "published" };
+    if (options.mode) {
+      filter.supportedModes = options.mode;
+    }
+
+    const sortOptions: Record<string, 1 | -1> =
+      options.sort === "plays"
+        ? { "stats.plays": -1 }
+        : options.sort === "likes"
+          ? { "stats.likes": -1 }
+          : { updatedAt: -1 };
+
+    const [maps, total] = await Promise.all([
+      MapModel.find(filter).sort(sortOptions).skip(skip).limit(limit).exec(),
+      MapModel.countDocuments(filter),
+    ]);
+
+    return { maps: maps.map((m) => this.mapToEntity(m)), total };
+  }
+
+  async update(
+    id: string,
+    authorId: string,
+    update: MapUpdateOptions,
+  ): Promise<IMap | null> {
+    const map = await MapModel.findOneAndUpdate(
+      { _id: id, authorId },
+      { $set: update },
+      { new: true, runValidators: true },
+    ).exec();
+    return map ? this.mapToEntity(map) : null;
+  }
+
+  async delete(id: string, authorId: string): Promise<boolean> {
+    const result = await MapModel.deleteOne({ _id: id, authorId }).exec();
+    return result.deletedCount > 0;
+  }
+
+  async incrementPlays(id: string): Promise<void> {
+    await MapModel.updateOne(
+      { _id: id },
+      { $inc: { "stats.plays": 1 } },
+    ).exec();
+  }
+
+  async toggleLike(id: string, userId: string): Promise<"liked" | "unliked"> {
+    const LikeModel = (await import("#/infra/db/models/like-model")).LikeModel;
+    const existing = await LikeModel.findOne({ mapId: id, userId }).exec();
+    if (existing) {
+      await existing.deleteOne();
+      await MapModel.updateOne(
+        { _id: id },
+        { $inc: { "stats.likes": -1 } },
+      ).exec();
+      return "unliked";
+    }
+    await LikeModel.create({ mapId: id, userId });
+    await MapModel.updateOne(
+      { _id: id },
+      { $inc: { "stats.likes": 1 } },
+    ).exec();
+    return "liked";
+  }
+}

--- a/packages/engine/src/domain/game/base-game.ts
+++ b/packages/engine/src/domain/game/base-game.ts
@@ -16,6 +16,7 @@ import { PlayerStatus } from "#/domain/player/player-status";
 import type { Team } from "#/domain/team/interfaces";
 import { VisibilityMap } from "#/domain/vision/visibility-map";
 import type { IVisionGrid } from "#/domain/vision/vision-grid";
+import type { ICoordinate } from "#/math/coordinate";
 import { GridType } from "#/math/grid-2d";
 
 /**
@@ -33,6 +34,9 @@ export abstract class BaseGame implements IBaseGame {
   readonly teams: Map<string, Team> = new Map();
   readonly effectRegistry = new EffectRegistry();
   protected readonly visibilityMap: VisibilityMap;
+
+  /** Explicit player→coordinate mapping for custom maps. Set before calling startGame(). */
+  spawnPositions?: Map<string, ICoordinate>;
 
   constructor(input: GridInput) {
     if ("grid" in input) {
@@ -230,6 +234,18 @@ export abstract class BaseGame implements IBaseGame {
   protected assignStartPositions(
     targetTerrain: Terrain = Terrain.GENERAL,
   ): void {
+    if (this.spawnPositions) {
+      for (const [playerId, coord] of this.spawnPositions) {
+        const cell = this.grid.get(coord);
+        const player = this.players.get(playerId);
+        if (cell && player) {
+          cell.owner = player;
+          cell.terrain = targetTerrain;
+        }
+      }
+      return;
+    }
+
     let index = 0;
     const playersArray = Array.from(this.players.values());
     this.grid.forEach((cell) => {

--- a/packages/engine/src/domain/game/interfaces.ts
+++ b/packages/engine/src/domain/game/interfaces.ts
@@ -7,6 +7,7 @@ import type { Grid } from "#/domain/grid/grid";
 import type { IPlayer, IPlayerState } from "#/domain/player/interfaces";
 import type { Team } from "#/domain/team/interfaces";
 import type { IVisionGrid } from "#/domain/vision/vision-grid";
+import type { ICoordinate } from "#/math/coordinate";
 
 /**
  * The root state of the Game Engine.
@@ -32,6 +33,9 @@ export interface IBaseGame {
 
   /** Map of all teams (ID -> State). */
   readonly teams: Map<string, Team>;
+
+  /** Explicit player→coordinate mapping for custom maps. */
+  spawnPositions?: Map<string, ICoordinate>;
 
   /**
    * Starts the internal tick counter and troop growth timers.

--- a/packages/shared-types/src/custom-map.ts
+++ b/packages/shared-types/src/custom-map.ts
@@ -1,0 +1,71 @@
+import type { GameMode, GridType, Terrain } from "@generals-plus/engine";
+
+export interface CellTemplate {
+  terrain: Terrain;
+  troopCount: number | null;
+  siteIndex: number | null;
+}
+
+export interface SpawnPoint {
+  x: number;
+  y: number;
+  teamId: string;
+  slot: number;
+}
+
+export interface SquareGridBounds {
+  width: number;
+  height: number;
+}
+
+export interface HexGridBounds {
+  left: number;
+  right: number;
+  leftSlant: number;
+  rightSlant: number;
+}
+
+export interface GridTemplate {
+  gridType: GridType;
+  bounds: SquareGridBounds | HexGridBounds;
+  cells: CellTemplate[][];
+  track?: { x: number; y: number }[];
+  spawns: SpawnPoint[];
+}
+
+export interface CustomMap {
+  id: string;
+  name: string;
+  description: string;
+  authorId: string;
+  authorName: string;
+  grid: GridTemplate;
+  supportedModes: GameMode[];
+  minPlayers: number;
+  maxPlayers: number;
+  tags: string[];
+  status: "draft" | "published";
+  stats: { plays: number; likes: number };
+  thumbnail: string;
+  createdAt: string | Date;
+  updatedAt: string | Date;
+}
+
+export interface CustomMapListResponse {
+  maps: CustomMap[];
+  total: number;
+}
+
+export interface CreateCustomMapRequest {
+  name: string;
+  description?: string;
+  grid: GridTemplate;
+  supportedModes: GameMode[];
+  minPlayers: number;
+  maxPlayers: number;
+  tags?: string[];
+  status?: "draft" | "published";
+  thumbnail?: string;
+}
+
+export type UpdateCustomMapRequest = Partial<CreateCustomMapRequest>;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,4 +1,5 @@
 export * from "#/color-palette";
+export * from "#/custom-map";
 export * from "#/custom-room";
 export * from "#/messages";
 export * from "#/player-ratings";

--- a/packages/shared-types/src/schema/setup-state.ts
+++ b/packages/shared-types/src/schema/setup-state.ts
@@ -20,6 +20,9 @@ export class SetupState extends Schema {
 
   @type("string") mapType: GridType = GridType.SQUARE;
 
+  @type("string") mapSource: "generated" | "custom" = "generated";
+  @type("string") customMapId: string = "";
+
   // Map dimensions for square maps
   @type("number") mapWidth: number = 24;
   @type("number") mapHeight: number = 16;

--- a/packages/shared-types/src/setup-settings.ts
+++ b/packages/shared-types/src/setup-settings.ts
@@ -6,6 +6,8 @@ interface BaseSetupSettings {
   maxPlayers: number;
   playersPerTeam: number;
   mapType: GridType;
+  mapSource: "generated" | "custom";
+  customMapId: string;
   mapWidth: number;
   mapHeight: number;
   mapLeft: number;


### PR DESCRIPTION
Closes #155 .

This pull request introduces major enhancements to the custom maps feature in the client, enabling users to pick, preview, and use custom maps when configuring game settings. It also adds a new API layer for interacting with custom maps and refines the UI to support these workflows. Additionally, it introduces a new, modular, and performant map editor canvas using PixiJS for rendering.

**Custom Maps Integration and Game Settings Improvements:**

* Added support for selecting between generated and custom maps in the `GameSettings` UI, including a dialog for browsing and picking custom maps. The UI now displays map details and disables incompatible fields when a custom map is selected. Only game modes supported by the selected map are enabled. (`apps/client/src/features/game/components/game-settings.tsx`) [[1]](diffhunk://#diff-57687d1f81fa91baad1242360b364fc8330288731ab42cd726b963ee9d1b1485R5-R15) [[2]](diffhunk://#diff-57687d1f81fa91baad1242360b364fc8330288731ab42cd726b963ee9d1b1485R27-R28) [[3]](diffhunk://#diff-57687d1f81fa91baad1242360b364fc8330288731ab42cd726b963ee9d1b1485R138-R162) [[4]](diffhunk://#diff-57687d1f81fa91baad1242360b364fc8330288731ab42cd726b963ee9d1b1485L181-R239) [[5]](diffhunk://#diff-57687d1f81fa91baad1242360b364fc8330288731ab42cd726b963ee9d1b1485R253-R274) [[6]](diffhunk://#diff-57687d1f81fa91baad1242360b364fc8330288731ab42cd726b963ee9d1b1485R287-R322) [[7]](diffhunk://#diff-57687d1f81fa91baad1242360b364fc8330288731ab42cd726b963ee9d1b1485L239-R359) [[8]](diffhunk://#diff-57687d1f81fa91baad1242360b364fc8330288731ab42cd726b963ee9d1b1485L314-R425)

* Added a "Maps" button to the lobby page, providing users with direct navigation to the custom maps section. (`apps/client/src/features/lobby/pages/lobby-page.tsx`) [[1]](diffhunk://#diff-f6d88e6b7eb025c016bc28539b057b487d6fa728cae070556aadb9ac873a0938L7-R7) [[2]](diffhunk://#diff-f6d88e6b7eb025c016bc28539b057b487d6fa728cae070556aadb9ac873a0938R156-R161)

**API Layer for Custom Maps:**

* Introduced a new `mapsApi` module that provides methods to list, retrieve, create, update, delete, and like/unlike custom maps via HTTP requests, handling authentication and error responses. (`apps/client/src/features/map-editor/api/maps-api.ts`)

**Map Editor Canvas Refactor:**

* Implemented a new `EditorCanvas` component using PixiJS for highly performant and modular rendering of map cells, terrain, spawn points, and other map features. The canvas supports both square and hex grid types and is optimized for editor workflows. (`apps/client/src/features/map-editor/components/editor-canvas.tsx`)