### PR TITLE
fix(server): fetch fresh user data on room join to avoid stale displayName

### DIFF
--- a/apps/server/src/features/auth/auth-config.ts
+++ b/apps/server/src/features/auth/auth-config.ts
@@ -83,10 +83,13 @@ auth.settings.onEmailConfirmed = async (email: string) => {
   return await userRepository.verifyEmail(email);
 };
 
+const FALLBACK_DISPLAY_NAME = "Player";
+
 /**
  * Fetch fresh user data from the database, falling back to the provided
  * decoded payload when the user ID is missing, the lookup fails, or the
- * user record is gone. The password field is always stripped.
+ * user record is gone. The password field is always stripped and
+ * displayName is guaranteed to be a non-empty string.
  */
 async function freshUserFromDB(
   data: Record<string, unknown>,
@@ -102,14 +105,20 @@ async function freshUserFromDB(
     const user = await userRepository.findById(userId);
     if (user) {
       const { password: _, ...safeData } = user;
-      return safeData;
+      return {
+        ...safeData,
+        displayName: safeData.displayName || FALLBACK_DISPLAY_NAME,
+      };
     }
   } catch {
     // Fall through to decoded token data
   }
 
   const { password: _, ...safeData } = data;
-  return safeData;
+  return {
+    ...safeData,
+    displayName: safeData.displayName || FALLBACK_DISPLAY_NAME,
+  };
 }
 
 /**

--- a/apps/server/src/features/auth/auth-config.ts
+++ b/apps/server/src/features/auth/auth-config.ts
@@ -83,10 +83,16 @@ auth.settings.onEmailConfirmed = async (email: string) => {
   return await userRepository.verifyEmail(email);
 };
 
-// Return fresh user data from the database instead of stale JWT payload.
-// This ensures fields like ratings are always up-to-date on page load.
-auth.settings.onParseToken = async (data: Record<string, unknown>) => {
-  const userId = data.id as string;
+/**
+ * Fetch fresh user data from the database, falling back to the provided
+ * decoded payload when the user ID is missing, the lookup fails, or the
+ * user record is gone. The password field is always stripped.
+ */
+async function freshUserFromDB(
+  data: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const userId = data.id as string | undefined;
+
   if (!userId) {
     const { password: _, ...safeData } = data;
     return safeData;
@@ -94,16 +100,33 @@ auth.settings.onParseToken = async (data: Record<string, unknown>) => {
 
   try {
     const user = await userRepository.findById(userId);
-    if (!user) {
-      const { password: _, ...safeData } = data;
+    if (user) {
+      const { password: _, ...safeData } = user;
       return safeData;
     }
-    const { password: _, ...safeData } = user;
-    return safeData;
   } catch {
-    const { password: _, ...safeData } = data;
-    return safeData;
+    // Fall through to decoded token data
   }
-};
+
+  const { password: _, ...safeData } = data;
+  return safeData;
+}
+
+/**
+ * Verify a JWT token and return fresh user data from the database.
+ *
+ * Used by room `onAuth` methods to ensure displayName and other fields
+ * are always current, even if the JWT was issued before a profile update.
+ */
+export async function resolveAuthUser(
+  token: string,
+): Promise<Record<string, unknown>> {
+  const decoded = (await JWT.verify(token)) as Record<string, unknown>;
+  return freshUserFromDB(decoded);
+}
+
+// Return fresh user data from the database instead of stale JWT payload.
+// This ensures fields like ratings are always up-to-date on page load.
+auth.settings.onParseToken = freshUserFromDB;
 
 export { auth };

--- a/apps/server/src/features/match/match-room.ts
+++ b/apps/server/src/features/match/match-room.ts
@@ -1,4 +1,3 @@
-import { JWT } from "@colyseus/auth";
 import type { Client } from "@colyseus/core";
 import { logger, Room } from "@colyseus/core";
 import { StateView } from "@colyseus/schema";
@@ -30,6 +29,7 @@ import {
 } from "@generals-plus/shared-types";
 import * as z from "zod";
 
+import { resolveAuthUser } from "#/features/auth/auth-config";
 import { createPlayer } from "#/features/player/utils";
 import { calculateNewRatings } from "#/features/rating/rating-service";
 import { parseRoomData } from "#/features/room-data";
@@ -242,7 +242,7 @@ export class MatchRoom extends Room<{
   }
 
   static async onAuth(token: string, _options: unknown, _context: unknown) {
-    return JWT.verify(token);
+    return resolveAuthUser(token);
   }
 
   onJoin(client: Client, _options: unknown) {

--- a/apps/server/src/features/queue/queue-room.ts
+++ b/apps/server/src/features/queue/queue-room.ts
@@ -282,9 +282,23 @@ export class MatchQueueRoom extends QueueRoom {
     }
   }
 
-  /** Verify the client auth token before allowing queue participation. */
+  /** Verify the client auth token and return fresh user data from the database. */
   static async onAuth(token: string) {
-    return JWT.verify(token);
+    const decoded = (await JWT.verify(token)) as Record<string, unknown>;
+    const userId = decoded?.id as string | undefined;
+    if (!userId) return decoded;
+
+    try {
+      const user = await userRepository.findById(userId);
+      if (user) {
+        const { password: _, ...safeData } = user;
+        return safeData;
+      }
+    } catch {
+      // Fall through to decoded token data
+    }
+
+    return decoded;
   }
 
   /**

--- a/apps/server/src/features/queue/queue-room.ts
+++ b/apps/server/src/features/queue/queue-room.ts
@@ -1,4 +1,3 @@
-import { JWT } from "@colyseus/auth";
 import type { Client, QueueOptions } from "@colyseus/core";
 import { logger, matchMaker, QueueRoom } from "@colyseus/core";
 import {
@@ -15,6 +14,7 @@ import {
   ROOM_NAMES,
 } from "@generals-plus/shared-types";
 
+import { resolveAuthUser } from "#/features/auth/auth-config";
 import { createGame, generateSeed } from "#/features/game/utils";
 import {
   BASE_TICK_INTERVAL,
@@ -284,21 +284,7 @@ export class MatchQueueRoom extends QueueRoom {
 
   /** Verify the client auth token and return fresh user data from the database. */
   static async onAuth(token: string) {
-    const decoded = (await JWT.verify(token)) as Record<string, unknown>;
-    const userId = decoded?.id as string | undefined;
-    if (!userId) return decoded;
-
-    try {
-      const user = await userRepository.findById(userId);
-      if (user) {
-        const { password: _, ...safeData } = user;
-        return safeData;
-      }
-    } catch {
-      // Fall through to decoded token data
-    }
-
-    return decoded;
+    return resolveAuthUser(token);
   }
 
   /**

--- a/apps/server/src/features/setup/setup-room.ts
+++ b/apps/server/src/features/setup/setup-room.ts
@@ -39,8 +39,10 @@ import {
   onSetupRoomDisposed,
 } from "#/features/setup/custom-room-registry";
 import { setupSettingsUpdateSchema } from "#/features/setup/schemas";
+import { MongoUserRepository } from "#/infra/db/repositories/MongoUserRepository";
 
 const DEFAULT_MAX_PLAYERS = 8;
+const userRepository = new MongoUserRepository();
 const SETUP_TEAM_PREFIX = "setup_team_";
 const DEMOLITION_FINAL_TEAM_IDS = ["attackers", "defenders"] as const;
 const DEMOLITION_SETUP_TEAM_IDS = ["attackers", "defenders"] as const;
@@ -150,7 +152,21 @@ export class SetupRoom extends Room<{ state: SetupState }> {
   }
 
   static async onAuth(token: string) {
-    return JWT.verify(token);
+    const decoded = (await JWT.verify(token)) as Record<string, unknown>;
+    const userId = decoded?.id as string | undefined;
+    if (!userId) return decoded;
+
+    try {
+      const user = await userRepository.findById(userId);
+      if (user) {
+        const { password: _, ...safeData } = user;
+        return safeData;
+      }
+    } catch {
+      // Fall through to decoded token data
+    }
+
+    return decoded;
   }
 
   async onJoin(client: Client) {

--- a/apps/server/src/features/setup/setup-room.ts
+++ b/apps/server/src/features/setup/setup-room.ts
@@ -1,4 +1,3 @@
-import { JWT } from "@colyseus/auth";
 import type { Client } from "@colyseus/core";
 import { logger, matchMaker, Room } from "@colyseus/core";
 import type { CollapseShape, GridGeneratorInput } from "@generals-plus/engine";
@@ -26,6 +25,7 @@ import {
   SetupState,
 } from "@generals-plus/shared-types";
 
+import { resolveAuthUser } from "#/features/auth/auth-config";
 import type { CreateGameOptions } from "#/features/game/utils";
 import { createGame, generateSeed } from "#/features/game/utils";
 import {
@@ -39,10 +39,8 @@ import {
   onSetupRoomDisposed,
 } from "#/features/setup/custom-room-registry";
 import { setupSettingsUpdateSchema } from "#/features/setup/schemas";
-import { MongoUserRepository } from "#/infra/db/repositories/MongoUserRepository";
 
 const DEFAULT_MAX_PLAYERS = 8;
-const userRepository = new MongoUserRepository();
 const SETUP_TEAM_PREFIX = "setup_team_";
 const DEMOLITION_FINAL_TEAM_IDS = ["attackers", "defenders"] as const;
 const DEMOLITION_SETUP_TEAM_IDS = ["attackers", "defenders"] as const;
@@ -152,21 +150,7 @@ export class SetupRoom extends Room<{ state: SetupState }> {
   }
 
   static async onAuth(token: string) {
-    const decoded = (await JWT.verify(token)) as Record<string, unknown>;
-    const userId = decoded?.id as string | undefined;
-    if (!userId) return decoded;
-
-    try {
-      const user = await userRepository.findById(userId);
-      if (user) {
-        const { password: _, ...safeData } = user;
-        return safeData;
-      }
-    } catch {
-      // Fall through to decoded token data
-    }
-
-    return decoded;
+    return resolveAuthUser(token);
   }
 
   async onJoin(client: Client) {

--- a/apps/server/tests/features/match/match-room.test.ts
+++ b/apps/server/tests/features/match/match-room.test.ts
@@ -865,13 +865,14 @@ describe("MatchRoom", () => {
   // ── Error branches and edge cases ─────────────────────────────
 
   describe("error branches and edge cases", () => {
-    it("onAuth delegates to JWT.verify", async () => {
+    it("onAuth returns fresh user data via resolveAuthUser", async () => {
       const verifySpy = vi
         .spyOn(JWT, "verify")
-        .mockResolvedValue({ sub: "u1" });
+        .mockResolvedValue({ id: "u1", displayName: "OldName" });
       const res = await MatchRoom.onAuth("token", undefined, undefined);
       expect(verifySpy).toHaveBeenCalledWith("token");
-      expect(res).toEqual({ sub: "u1" });
+      // No DB mock → falls back to decoded token payload (password stripped)
+      expect(res).toEqual({ id: "u1", displayName: "OldName" });
       verifySpy.mockRestore();
     });
 

--- a/apps/server/tests/features/queue/queue-room.test.ts
+++ b/apps/server/tests/features/queue/queue-room.test.ts
@@ -25,6 +25,7 @@ function captureErrors(client: {
 
 const mocks = vi.hoisted(() => ({
   getRating: vi.fn().mockResolvedValue(1000),
+  findById: vi.fn().mockResolvedValue(null),
   createGame: vi.fn(),
   generateSeed: vi.fn(() => 12345),
 }));
@@ -32,6 +33,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("#/infra/db/repositories/MongoUserRepository", () => ({
   MongoUserRepository: class {
     getRating = mocks.getRating;
+    findById = mocks.findById;
   },
 }));
 
@@ -445,6 +447,27 @@ describe("MatchQueueRoom", () => {
       await expect(
         MatchQueueRoom.onAuth("invalid.token.here"),
       ).rejects.toThrow();
+    });
+
+    it("returns fresh displayName from DB when user has updated profile", async () => {
+      const token = await JWT.sign({
+        id: "u1",
+        displayName: "OldName",
+      });
+
+      mocks.findById.mockResolvedValueOnce({
+        id: "u1",
+        displayName: "UpdatedName",
+        password: "secret",
+      });
+
+      const result = (await MatchQueueRoom.onAuth(token)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.displayName).toBe("UpdatedName");
+      expect(result).not.toHaveProperty("password");
     });
   });
 });


### PR DESCRIPTION
Room onAuth previously called JWT.verify() directly, which only decoded the token payload containing the displayName from login time. When a user updated their displayName in profile, the JWT was not refreshed, so subsequent room joins still showed the old name.

Now onAuth verifies the token then fetches the latest user record from the database, consistent with the existing onParseToken pattern in auth-config.ts.