### PR TITLE
fix(engine): bomb site icon should be displayed in demolition mode

### DIFF
--- a/apps/client/src/features/game/renderer/layers/grid.tsx
+++ b/apps/client/src/features/game/renderer/layers/grid.tsx
@@ -1,3 +1,4 @@
+import { Visibility } from "@generals-plus/engine";
 import { extend } from "@pixi/react";
 import { Graphics } from "pixi.js";
 import { useCallback } from "react";
@@ -29,6 +30,10 @@ export function getCellFillColor(
     return playerColors.get(cell.ownerIndex) ?? 0x333333;
   }
 
+  if (cell.visibility === Visibility.SHROUDED) {
+    return 0x525356;
+  }
+
   if ((cell.troopCount ?? 0) > 0) {
     return NeutralTroopCellColor;
   }
@@ -50,7 +55,9 @@ export function GridLayer({ tick, grid, playerColors }: GridLayerProps) {
 
         const color = cell.ownerIndex
           ? (playerColors.get(cell.ownerIndex) ?? 0x333333)
-          : TerrainTheme[cell.terrain]?.color || 0xffffff;
+          : cell.visibility === Visibility.SHROUDED
+            ? 0x525356
+            : TerrainTheme[cell.terrain]?.color || 0xffffff;
 
         g.fill(color);
 

--- a/apps/client/src/features/game/renderer/layers/site-label.tsx
+++ b/apps/client/src/features/game/renderer/layers/site-label.tsx
@@ -1,4 +1,4 @@
-import { Terrain } from "@generals-plus/engine";
+import { Terrain, Visibility } from "@generals-plus/engine";
 import { extend } from "@pixi/react";
 import { Container, Text, TextStyle } from "pixi.js";
 import { useMemo } from "react";
@@ -11,15 +11,24 @@ import type {
 
 extend({ Container, Text });
 
-const SITE_TEXT_STYLE = new TextStyle({
+const siteLabelBaseStyle = {
   fontFamily: RenderConfig.siteLabelFontFamily,
   fontSize: RenderConfig.cellStride * RenderConfig.siteLabelFontSizeRatio,
   fontWeight: RenderConfig.siteLabelFontWeight,
-  fill: RenderConfig.siteLabelColor,
   stroke: {
     color: RenderConfig.siteLabelStrokeColor,
     width: RenderConfig.siteLabelStrokeWidth,
   },
+};
+
+const SITE_TEXT_STYLE = new TextStyle({
+  ...siteLabelBaseStyle,
+  fill: RenderConfig.siteLabelColor,
+});
+
+const SHROUDED_SITE_TEXT_STYLE = new TextStyle({
+  ...siteLabelBaseStyle,
+  fill: 0x8a8d93,
 });
 
 interface SiteLabelLayerProps {
@@ -59,7 +68,7 @@ export function SiteLabelLayer({ grid, tick }: SiteLabelLayerProps) {
             anchor={0.5}
             x={x * RenderConfig.cellStride}
             y={y * RenderConfig.cellStride}
-            style={SITE_TEXT_STYLE}
+            style={cell.visibility === Visibility.SHROUDED ? SHROUDED_SITE_TEXT_STYLE : SITE_TEXT_STYLE}
           />
         );
       })}

--- a/apps/client/src/features/game/renderer/layers/site-label.tsx
+++ b/apps/client/src/features/game/renderer/layers/site-label.tsx
@@ -37,7 +37,7 @@ interface SiteLabelLayerProps {
 }
 
 export function SiteLabelLayer({ grid, tick }: SiteLabelLayerProps) {
-  // Assume that site labels remain unchanged across ticks, but we recompute when tick changes to handle in-place grid mutation on initialization.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: tick is intentionally included to force a refresh each tick, since cell visibility changes across ticks
   const siteCells = useMemo(() => {
     const cells: Array<{ cell: RenderGridCell; label: string }> = [];
     grid.forEach((cell) => {
@@ -68,7 +68,11 @@ export function SiteLabelLayer({ grid, tick }: SiteLabelLayerProps) {
             anchor={0.5}
             x={x * RenderConfig.cellStride}
             y={y * RenderConfig.cellStride}
-            style={cell.visibility === Visibility.SHROUDED ? SHROUDED_SITE_TEXT_STYLE : SITE_TEXT_STYLE}
+            style={
+              cell.visibility === Visibility.SHROUDED
+                ? SHROUDED_SITE_TEXT_STYLE
+                : SITE_TEXT_STYLE
+            }
           />
         );
       })}

--- a/apps/client/src/features/game/renderer/layers/site-label.tsx
+++ b/apps/client/src/features/game/renderer/layers/site-label.tsx
@@ -24,10 +24,11 @@ const SITE_TEXT_STYLE = new TextStyle({
 
 interface SiteLabelLayerProps {
   grid: RenderGrid;
+  tick?: number;
 }
 
-export function SiteLabelLayer({ grid }: SiteLabelLayerProps) {
-  // Assume that site labels remain unchanged across ticks, so only compute once on mount.
+export function SiteLabelLayer({ grid, tick }: SiteLabelLayerProps) {
+  // Assume that site labels remain unchanged across ticks, but we recompute when tick changes to handle in-place grid mutation on initialization.
   const siteCells = useMemo(() => {
     const cells: Array<{ cell: RenderGridCell; label: string }> = [];
     grid.forEach((cell) => {
@@ -44,7 +45,7 @@ export function SiteLabelLayer({ grid }: SiteLabelLayerProps) {
       }
     });
     return cells;
-  }, [grid]);
+  }, [grid, tick]);
 
   return (
     <pixiContainer>

--- a/apps/client/src/features/game/renderer/map-renderer.tsx
+++ b/apps/client/src/features/game/renderer/map-renderer.tsx
@@ -146,7 +146,7 @@ export function MapRenderer({
           cartSize={cartSize}
         />
       )}
-      <SiteLabelLayer grid={grid} />
+      <SiteLabelLayer grid={grid} tick={tick} />
       <MoveQueueLayer grid={grid} moveQueue={moveQueue} />
       <TroopLayer
         tick={tick}

--- a/apps/client/tests/features/game/renderer/grid-layer.test.ts
+++ b/apps/client/tests/features/game/renderer/grid-layer.test.ts
@@ -41,4 +41,38 @@ describe("getCellFillColor", () => {
 
     expect(color).toBe(TerrainTheme[Terrain.PLAIN].color);
   });
+
+  it("returns shroud color for SHROUDED cells regardless of terrain", () => {
+    const color = getCellFillColor(
+      {
+        coordinate: { x: 0, y: 0 },
+        visibility: Visibility.SHROUDED,
+        terrain: Terrain.BOMB_SITE,
+        troopCount: null,
+        ownerIndex: null,
+        siteIndex: 0,
+        item: null,
+      },
+      new Map(),
+    );
+
+    expect(color).toBe(0x525356);
+  });
+
+  it("returns shroud color for SHROUDED cells even with troops present", () => {
+    const color = getCellFillColor(
+      {
+        coordinate: { x: 0, y: 0 },
+        visibility: Visibility.SHROUDED,
+        terrain: Terrain.PLAIN,
+        troopCount: 10,
+        ownerIndex: null,
+        siteIndex: null,
+        item: null,
+      },
+      new Map(),
+    );
+
+    expect(color).toBe(0x525356);
+  });
 });

--- a/packages/engine/src/domain/vision/visibility-map.ts
+++ b/packages/engine/src/domain/vision/visibility-map.ts
@@ -78,7 +78,7 @@ export function createVisionCell(
       const isBombSite = cell.terrain === Terrain.BOMB_SITE;
       return {
         coordinate: cell.coordinate,
-        visibility,
+        visibility: isBombSite ? Visibility.SHROUDED : visibility,
         terrain: isBombSite ? Terrain.BOMB_SITE : HiddenTerrain,
         troopCount: null,
         owner: null,

--- a/packages/engine/src/domain/vision/visibility-map.ts
+++ b/packages/engine/src/domain/vision/visibility-map.ts
@@ -57,31 +57,36 @@ export function createVisionCell(
         siteIndex: cell.siteIndex,
         willCollapse: cell.willCollapse,
       };
-    case Visibility.SHROUDED:
+    case Visibility.SHROUDED: {
+      const isBombSite = cell.terrain === Terrain.BOMB_SITE;
       return {
         coordinate: cell.coordinate,
         visibility,
-        terrain:
-          cell.terrain === Terrain.MOUNTAIN || cell.terrain === Terrain.CITY
+        terrain: isBombSite
+          ? Terrain.BOMB_SITE
+          : cell.terrain === Terrain.MOUNTAIN || cell.terrain === Terrain.CITY
             ? MaskedTerrain.MAYBE_MOUNTAIN
             : MaskedTerrain.MAYBE_PLAIN,
         troopCount: null,
         owner: null,
         item: attackerItem,
-        siteIndex: null,
+        siteIndex: isBombSite ? cell.siteIndex : null,
         willCollapse: cell.willCollapse,
       };
-    case Visibility.HIDDEN:
+    }
+    case Visibility.HIDDEN: {
+      const isBombSite = cell.terrain === Terrain.BOMB_SITE;
       return {
         coordinate: cell.coordinate,
         visibility,
-        terrain: HiddenTerrain,
+        terrain: isBombSite ? Terrain.BOMB_SITE : HiddenTerrain,
         troopCount: null,
         owner: null,
         item: attackerItem,
-        siteIndex: null,
+        siteIndex: isBombSite ? cell.siteIndex : null,
         willCollapse: cell.willCollapse,
       };
+    }
   }
 }
 

--- a/packages/engine/tests/domain/vision/visibility-map.test.ts
+++ b/packages/engine/tests/domain/vision/visibility-map.test.ts
@@ -219,4 +219,25 @@ describe("VisibilityMap", () => {
     expect(defenderPerceivedCellWithSight?.item).not.toBeNull();
     expect(defenderPerceivedCellWithSight?.item?.type).toBe(ItemType.BOMB);
   });
+
+  it("always shows BOMB_SITE terrain and siteIndex under SHROUDED and HIDDEN states", () => {
+    const cell = new Cell({
+      coordinate: { x: 1, y: 1 },
+      terrain: Terrain.BOMB_SITE,
+      siteIndex: 2, // site 'C'
+      troopCount: 5,
+    });
+
+    const shrouded = createVisionCell(cell, Visibility.SHROUDED);
+    expect(shrouded.visibility).toBe(Visibility.SHROUDED);
+    expect(shrouded.terrain).toBe(Terrain.BOMB_SITE);
+    expect(shrouded.siteIndex).toBe(2);
+    expect(shrouded.troopCount).toBeNull(); // troops still hidden under shroud
+
+    const hidden = createVisionCell(cell, Visibility.HIDDEN);
+    expect(hidden.visibility).toBe(Visibility.HIDDEN);
+    expect(hidden.terrain).toBe(Terrain.BOMB_SITE);
+    expect(hidden.siteIndex).toBe(2);
+    expect(hidden.troopCount).toBeNull(); // troops still hidden when hidden
+  });
 });

--- a/packages/engine/tests/domain/vision/visibility-map.test.ts
+++ b/packages/engine/tests/domain/vision/visibility-map.test.ts
@@ -235,9 +235,9 @@ describe("VisibilityMap", () => {
     expect(shrouded.troopCount).toBeNull(); // troops still hidden under shroud
 
     const hidden = createVisionCell(cell, Visibility.HIDDEN);
-    expect(hidden.visibility).toBe(Visibility.HIDDEN);
+    expect(hidden.visibility).toBe(Visibility.SHROUDED); // HIDDEN bomb sites upgrade to SHROUDED so frontend can distinguish
     expect(hidden.terrain).toBe(Terrain.BOMB_SITE);
     expect(hidden.siteIndex).toBe(2);
-    expect(hidden.troopCount).toBeNull(); // troops still hidden when hidden
+    expect(hidden.troopCount).toBeNull(); // troops still hidden
   });
 });


### PR DESCRIPTION
Closes #178 .

This pull request enhances the handling and rendering of bomb sites on the game map, particularly when they are under SHROUDED or HIDDEN visibility states. The main improvements ensure that bomb site terrain and labels are always visible (albeit with limited information) even when the cell is not fully revealed, and that the UI updates correctly in response to visibility changes.

**Game rendering and UI updates:**

* Bomb site cells now always display their terrain type and site index under both SHROUDED and HIDDEN visibility states, instead of masking them as generic terrain. This ensures players can identify bomb sites even when they are not fully visible.
* The `SiteLabelLayer` now updates its labels’ style and color based on cell visibility, using a distinct style for shrouded sites, and is recomputed when the game tick changes to reflect in-place grid mutations. [[1]](diffhunk://#diff-5c89c58cbcc0534212ac42b0eb55926bba5c4d7f1b2e0e339ed40bfad933dad1L14-R40) [[2]](diffhunk://#diff-5c89c58cbcc0534212ac42b0eb55926bba5c4d7f1b2e0e339ed40bfad933dad1L47-R57) [[3]](diffhunk://#diff-5c89c58cbcc0534212ac42b0eb55926bba5c4d7f1b2e0e339ed40bfad933dad1L61-R71) [[4]](diffhunk://#diff-032d4bed5ea8f3562560a7139ec9d817b06a8d5ef107fe62612493935499a6b7L149-R149)
* Grid cell rendering now uses a specific color for shrouded cells to visually distinguish them from other terrain types. [[1]](diffhunk://#diff-d21baf0113ce969e19bca4f3576e879ed2ad64e8d1eb4ead9fd9067dd0cb9370R1) [[2]](diffhunk://#diff-d21baf0113ce969e19bca4f3576e879ed2ad64e8d1eb4ead9fd9067dd0cb9370R33-R36) [[3]](diffhunk://#diff-d21baf0113ce969e19bca4f3576e879ed2ad64e8d1eb4ead9fd9067dd0cb9370R58-R59)

**Game logic and testing:**

* The vision logic in `createVisionCell` is updated so bomb sites retain their terrain and site index under SHROUDED and HIDDEN states, and HIDDEN bomb sites are upgraded to SHROUDED for frontend clarity.
* New tests verify that bomb sites are always shown with the correct terrain and site index under SHROUDED and HIDDEN visibility, and that troop counts remain hidden.