### PR TITLE
feat(client): move backend url to environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# docker-compose
+MONGO_USERNAME=user
+MONGO_PASSWORD=pass

--- a/apps/client/.env.example
+++ b/apps/client/.env.example
@@ -1,0 +1,2 @@
+# Colyseus endpoint (leave empty for local dev default http://localhost:2567)
+VITE_COLYSEUS_ENDPOINT=

--- a/apps/client/src/features/game/api/colyseus-client.ts
+++ b/apps/client/src/features/game/api/colyseus-client.ts
@@ -1,5 +1,5 @@
 import { Client } from "@colyseus/sdk";
 
-const ENDPOINT = "http://localhost:2567";
+import { resolveColyseusEndpoint } from "#/infra/colyseus/connection";
 
-export const colyseusClient = new Client(ENDPOINT);
+export const colyseusClient = new Client(resolveColyseusEndpoint());

--- a/apps/client/src/infra/colyseus/connection.ts
+++ b/apps/client/src/infra/colyseus/connection.ts
@@ -2,7 +2,7 @@ import { Callbacks, Client } from "@colyseus/sdk";
 
 export { Callbacks };
 
-export const DEFAULT_COLYSEUS_ENDPOINT = "ws://localhost:2567";
+export const DEFAULT_COLYSEUS_ENDPOINT = "http://localhost:2567";
 
 export interface ColyseusAuthData<User = unknown> {
   user: User | null;

--- a/apps/client/src/infra/network/provider/colyseus.ts
+++ b/apps/client/src/infra/network/provider/colyseus.ts
@@ -261,7 +261,7 @@ export class ColyseusNetworkProvider<User = unknown>
     if (customRoomKey?.trim()) {
       payload.customRoomKey = customRoomKey.trim();
     }
-    return this.requestJson<CustomRoomCreation>("/custom-rooms", {
+    return this.requestJson<CustomRoomCreation>("custom-rooms", {
       method: "POST",
       body: JSON.stringify(payload),
     });
@@ -271,7 +271,7 @@ export class ColyseusNetworkProvider<User = unknown>
     customRoomKey: string,
   ): Promise<CustomRoomResolution> {
     return this.requestJson<CustomRoomResolution>(
-      `/custom-rooms/${encodeURIComponent(customRoomKey)}/resolve`,
+      `custom-rooms/${encodeURIComponent(customRoomKey)}/resolve`,
       {
         method: "POST",
         body: JSON.stringify({}),

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,8 @@ services:
     image: mongodb/mongodb-atlas-local
     hostname: mongodb
     environment:
-      - MONGODB_INITDB_ROOT_USERNAME=user
-      - MONGODB_INITDB_ROOT_PASSWORD=pass
+      - MONGODB_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-user}
+      - MONGODB_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-pass}
     ports:
       - 27017:27017
     volumes:


### PR DESCRIPTION
Closes #131 .

This pull request introduces environment variable improvements for local development, updates the Colyseus client endpoint resolution, and fixes some URL formatting issues in network provider methods. The main changes are grouped below:

**Environment variable and configuration improvements:**

* Added `MONGO_USERNAME` and `MONGO_PASSWORD` to `.env.example` for Docker Compose, and updated `docker-compose.yaml` to use these variables for MongoDB credentials. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1-R3) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L6-R7)
* Added `VITE_COLYSEUS_ENDPOINT` to `apps/client/.env.example` to allow configuration of the Colyseus endpoint via environment variable.

**Colyseus endpoint and connection updates:**

* Updated the Colyseus client in `colyseus-client.ts` to use a resolved endpoint via `resolveColyseusEndpoint`, improving flexibility for different environments.
* Changed the default Colyseus endpoint protocol from `ws://` to `http://` in `connection.ts` for consistency.

**Network provider bug fixes:**

* Fixed the URLs in `ColyseusNetworkProvider` methods by removing leading slashes, ensuring correct endpoint resolution for custom room creation and resolution. [[1]](diffhunk://#diff-38edee62de1c64e9f5d9e2d2441bf5a72394d3da490c682dcf7c8d7ac63c546fL264-R264) [[2]](diffhunk://#diff-38edee62de1c64e9f5d9e2d2441bf5a72394d3da490c682dcf7c8d7ac63c546fL274-R274)