### PR TITLE
fix(mapeditor, demolition): spawn points will be tranformed to capital

### DIFF
--- a/packages/engine/src/domain/game/base-game.ts
+++ b/packages/engine/src/domain/game/base-game.ts
@@ -256,14 +256,27 @@ export abstract class BaseGame implements IBaseGame {
     targetTerrain: Terrain = Terrain.GENERAL,
   ): void {
     if (this.spawnPositions) {
+      const assignedCoords = new Set<string>();
       for (const [playerId, coord] of this.spawnPositions) {
         const cell = this.grid.get(coord);
         const player = this.players.get(playerId);
         if (cell && player) {
           cell.owner = player;
           cell.terrain = targetTerrain;
+          assignedCoords.add(`${coord.x},${coord.y}`);
         }
       }
+
+      this.grid.forEach((cell) => {
+        if (cell.terrain === Terrain.GENERAL) {
+          const coordKey = `${cell.coordinate.x},${cell.coordinate.y}`;
+          if (!assignedCoords.has(coordKey)) {
+            cell.terrain = Terrain.PLAIN;
+            cell.owner = null;
+            cell.troopCount = null;
+          }
+        }
+      });
       return;
     }
 
@@ -271,9 +284,16 @@ export abstract class BaseGame implements IBaseGame {
     const playersArray = Array.from(this.players.values());
     this.grid.forEach((cell) => {
       if (cell.terrain === Terrain.GENERAL) {
-        cell.terrain = targetTerrain;
-        cell.owner = playersArray[index] ?? null;
-        index += 1;
+        const player = playersArray[index];
+        if (player) {
+          cell.terrain = targetTerrain;
+          cell.owner = player;
+          index += 1;
+        } else {
+          cell.terrain = Terrain.PLAIN;
+          cell.owner = null;
+          cell.troopCount = null;
+        }
       }
     });
   }

--- a/packages/engine/tests/domain/game/base-game.test.ts
+++ b/packages/engine/tests/domain/game/base-game.test.ts
@@ -23,6 +23,10 @@ class TestGame extends BaseGame {
       mode: GameMode.CLASSIC,
     };
   }
+
+  public testAssignStartPositions(targetTerrain?: Terrain) {
+    this.assignStartPositions(targetTerrain);
+  }
 }
 
 function createGame(): TestGame {
@@ -85,5 +89,106 @@ describe("BaseGame", () => {
 
     expect(game.getVisionGrid("missing")).toBeNull();
     expect(game.getVisionGrid("p1")).not.toBeNull();
+  });
+
+  it("converts extra general cells to plain cells when spawnPositions is defined", () => {
+    const grid = new SquareGrid(3, 1, [
+      [
+        new Cell({
+          coordinate: { x: 0, y: 0 },
+          terrain: Terrain.GENERAL,
+          troopCount: 1,
+        }),
+        new Cell({
+          coordinate: { x: 1, y: 0 },
+          terrain: Terrain.GENERAL,
+          troopCount: 2,
+        }),
+        new Cell({
+          coordinate: { x: 2, y: 0 },
+          terrain: Terrain.GENERAL,
+          troopCount: 3,
+        }),
+      ],
+    ]);
+    const game = new TestGame({ grid });
+    const team = new StandardTeam("t1");
+    const player = new Player(team, "p1");
+    game.players.set(player.playerId, player);
+
+    // Map p1 to cell (0, 0)
+    game.spawnPositions = new Map([["p1", { x: 0, y: 0 }]]);
+
+    game.testAssignStartPositions();
+
+    const cell0 = grid.get({ x: 0, y: 0 });
+    const cell1 = grid.get({ x: 1, y: 0 });
+    const cell2 = grid.get({ x: 2, y: 0 });
+
+    // Assigned spawn cell should keep its terrain (defaults to GENERAL) and get owner
+    expect(cell0).not.toBeNull();
+    expect(cell0?.terrain).toBe(Terrain.GENERAL);
+    expect(cell0?.owner).toBe(player);
+
+    // Unassigned spawn cells should become PLAIN with null owner and null troopCount
+    expect(cell1).not.toBeNull();
+    expect(cell1?.terrain).toBe(Terrain.PLAIN);
+    expect(cell1?.owner).toBeNull();
+    expect(cell1?.troopCount).toBeNull();
+
+    expect(cell2).not.toBeNull();
+    expect(cell2?.terrain).toBe(Terrain.PLAIN);
+    expect(cell2?.owner).toBeNull();
+    expect(cell2?.troopCount).toBeNull();
+  });
+
+  it("converts extra general cells to plain cells when spawnPositions is NOT defined", () => {
+    const grid = new SquareGrid(3, 1, [
+      [
+        new Cell({
+          coordinate: { x: 0, y: 0 },
+          terrain: Terrain.GENERAL,
+          troopCount: 1,
+        }),
+        new Cell({
+          coordinate: { x: 1, y: 0 },
+          terrain: Terrain.GENERAL,
+          troopCount: 2,
+        }),
+        new Cell({
+          coordinate: { x: 2, y: 0 },
+          terrain: Terrain.GENERAL,
+          troopCount: 3,
+        }),
+      ],
+    ]);
+    const game = new TestGame({ grid });
+    const team1 = new StandardTeam("t1");
+    const team2 = new StandardTeam("t2");
+    const player1 = new Player(team1, "p1");
+    const player2 = new Player(team2, "p2");
+    game.players.set(player1.playerId, player1);
+    game.players.set(player2.playerId, player2);
+
+    game.testAssignStartPositions();
+
+    const cell0 = grid.get({ x: 0, y: 0 });
+    const cell1 = grid.get({ x: 1, y: 0 });
+    const cell2 = grid.get({ x: 2, y: 0 });
+
+    // First two general cells assigned to players
+    expect(cell0).not.toBeNull();
+    expect(cell0?.terrain).toBe(Terrain.GENERAL);
+    expect(cell0?.owner).toBe(player1);
+
+    expect(cell1).not.toBeNull();
+    expect(cell1?.terrain).toBe(Terrain.GENERAL);
+    expect(cell1?.owner).toBe(player2);
+
+    // Third general cell is extra and should become PLAIN with null owner and null troopCount
+    expect(cell2).not.toBeNull();
+    expect(cell2?.terrain).toBe(Terrain.PLAIN);
+    expect(cell2?.owner).toBeNull();
+    expect(cell2?.troopCount).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #182 .

This pull request updates the logic for assigning starting positions in the game grid to ensure that any unassigned "general" cells are converted to "plain" cells, preventing leftover generals when there are more general cells than players. It also adds comprehensive tests to verify this behavior in both scenarios: when spawn positions are specified and when they are not.

**Game logic improvements:**

* Updated the `assignStartPositions` method in `BaseGame` to convert any extra `GENERAL` terrain cells to `PLAIN` with no owner or troop count if they are not assigned to a player, both when `spawnPositions` is defined and when it is not.

**Testing enhancements:**

* Added a `testAssignStartPositions` helper to the `TestGame` class for easier testing of the start position assignment logic.
* Added new tests to verify that extra general cells are correctly converted to plain cells in both cases: with and without predefined `spawnPositions`.