### PR TITLE
feat(client/lobby): add help dialog with detailed rules for each game mode

### DIFF
--- a/apps/client/src/config/ui-constants.ts
+++ b/apps/client/src/config/ui-constants.ts
@@ -21,10 +21,111 @@ function formatGameMode(mode: string): string {
   return mode.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+export interface ModeHelpData {
+  summary: string;
+  rules: string[];
+}
+
+/** Detailed rules for each game mode, shown in the mode help dialog. */
+export const GAME_MODE_HELP: Record<GameMode, ModeHelpData> = {
+  [GameMode.CLASSIC]: {
+    summary: "Classic generals.io rules. Capture the enemy general to win.",
+    rules: [
+      "Capture all enemy generals to win.",
+      "Your general produces +1 troop per tick.",
+      "Cities produce +1 troop per tick once captured.",
+      "Losing your general eliminates you from the game.",
+      "When a general is captured, it becomes a city.",
+    ],
+  },
+  [GameMode.DEMOLITION]: {
+    summary:
+      "Attack/Defend mode. Attackers must plant and detonate a bomb. Defenders must stop them.",
+    rules: [
+      "Two teams: Attackers vs Defenders.",
+      "The bomb starts with a random attacker and can only be carried by attackers.",
+      "Attackers win by detonating the bomb at a bomb site or eliminating all defenders.",
+      "Defenders win by defusing the bomb, eliminating all attackers, or surviving until time runs out (3 min).",
+      "Planting takes 6 ticks; defusing takes 10 ticks.",
+      "The bomb explodes 90 ticks after being planted.",
+    ],
+  },
+  [GameMode.TURF_WAR]: {
+    summary:
+      "High-speed area control. The player who owns the most tiles when time runs out wins.",
+    rules: [
+      "Own the most territory when the timer ends (3 min) to win, or eliminate all enemies early.",
+      "All troop generation is doubled (2× speed).",
+      "Generals produce +2 troops/tick; cities produce +2 troops/tick.",
+      "When a general is captured, it becomes a plain tile.",
+      "The scoreboard shows each team's land percentage.",
+    ],
+  },
+  [GameMode.BIOHAZARD]: {
+    summary:
+      "Survival mode. Zombies try to infect all humans. Humans try to survive.",
+    rules: [
+      "Two factions: Zombies vs Humans.",
+      "Zombies win by infecting all humans.",
+      "Humans win by surviving until time runs out.",
+    ],
+  },
+  [GameMode.PAYLOAD]: {
+    summary: "Objective push. Teams escort a cart to the enemy base.",
+    rules: [
+      "Two teams compete to push a cart along a track toward the enemy base.",
+      "The cart requires at least 6 troops occupying its 3×3 area to move.",
+      "The cart advances every 4 ticks while being pushed.",
+      "Win by pushing the cart to the end of the track.",
+      "If time runs out (5 min), the team that pushed the cart furthest wins.",
+    ],
+  },
+  [GameMode.RUGBY]: {
+    summary: "Sports-style capture. Carry the ball to the enemy's goal zone.",
+    rules: [
+      "Two teams compete to carry the ball into the enemy's goal zone.",
+      "Score by reaching the opponent's goal with the ball.",
+    ],
+  },
+  [GameMode.COLLAPSE]: {
+    summary:
+      "Battle royale style. The playable map area steadily shrinks over time, forcing players together.",
+    rules: [
+      "Last team standing wins.",
+      "The safe zone shrinks every 30 seconds after an initial 60-second delay.",
+      "The map collapses in 6 stages, shrinking to a small final zone.",
+      "Tiles outside the safe zone become impassable void.",
+      "If your general is caught in the collapse, it is relocated to the safe zone.",
+      "Players with no safe land are eliminated.",
+    ],
+  },
+  [GameMode.DOMINATION]: {
+    summary:
+      "Control point mode. Capture and hold strategic locations on the map to accumulate score.",
+    rules: [
+      "Two teams compete to reach the target score (default 1000) first.",
+      "Capture flag tiles by moving your troops onto them.",
+      "Teams score points every tick for each flag they hold.",
+      "Holding a flag longer increases its score rate: 1 + floor(ticks held / 100).",
+      "If time runs out (5 min), the team with the highest score wins.",
+      "Players with no remaining land are eliminated.",
+    ],
+  },
+  [GameMode.ESPIONAGE]: {
+    summary:
+      "Intelligence gathering. Infiltrate the enemy base to steal intel or operate under heavy fog of war.",
+    rules: [
+      "Infiltrate the enemy base to steal intel.",
+      "Operate under heavy fog of war with limited vision.",
+    ],
+  },
+};
+
 /** Mode options presented by lobby and setup controls. */
 export const GAME_MODE_OPTIONS = Object.values(GameMode).map((mode) => ({
   id: mode,
   label: formatGameMode(mode),
+  help: GAME_MODE_HELP[mode],
   minPlayers: 2,
   isEnabled: SUPPORTED_GAME_MODES.has(mode),
 }));

--- a/apps/client/src/features/game/components/game-settings.tsx
+++ b/apps/client/src/features/game/components/game-settings.tsx
@@ -24,6 +24,7 @@ import {
 } from "#/components/ui/select";
 import { Switch } from "#/components/ui/switch";
 import { GAME_MODE_OPTIONS } from "#/config/ui-constants";
+import { ModeHelpButton } from "#/features/game/components/mode-help-button";
 import { mapsApi } from "#/features/map-editor/api/maps-api";
 import { MapPickerDialog } from "#/features/map-editor/components/map-picker-dialog";
 import { cn } from "#/lib/utils";
@@ -321,9 +322,15 @@ export function GameSettings({
         </div>
 
         <div className={fieldClassName}>
-          <Label id="game-mode-label" className={labelClassName}>
-            Game Mode
-          </Label>
+          <div className="flex items-center gap-1">
+            <Label id="game-mode-label" className={labelClassName}>
+              Game Mode
+            </Label>
+            <ModeHelpButton
+              gameMode={currentSettings.gameMode ?? GameMode.CLASSIC}
+              className="text-game-text-dim hover:text-game-text"
+            />
+          </div>
           <Select
             disabled={!isHost}
             value={currentSettings.gameMode ?? GameMode.CLASSIC}

--- a/apps/client/src/features/game/components/mode-help-button.tsx
+++ b/apps/client/src/features/game/components/mode-help-button.tsx
@@ -1,0 +1,81 @@
+import type { GameMode } from "@generals-plus/engine";
+import { CircleHelp } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "#/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "#/components/ui/dialog";
+import type { ModeHelpData } from "#/config/ui-constants";
+import { GAME_MODE_HELP, GAME_MODE_OPTIONS } from "#/config/ui-constants";
+
+function ModeHelpContent({ help }: { help: ModeHelpData }) {
+  return (
+    <div className="grid gap-3">
+      <DialogDescription className="text-sm text-game-text-dim">
+        {help.summary}
+      </DialogDescription>
+      <ul className="grid gap-1.5 text-xs text-game-text-dim">
+        {help.rules.map((rule) => (
+          <li key={rule} className="flex gap-2">
+            <span className="mt-1 size-1 shrink-0 rounded-full bg-game-text-dim" />
+            <span>{rule}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * Reusable help icon button that opens a dialog with mode rules.
+ *
+ * Place it inline next to a mode label to give players quick access to
+ * detailed rules for the selected game mode.
+ */
+export function ModeHelpButton({
+  gameMode,
+  className,
+}: {
+  gameMode: GameMode;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const option = GAME_MODE_OPTIONS.find((o) => o.id === gameMode);
+  const label = option?.label ?? gameMode;
+  const help = GAME_MODE_HELP[gameMode];
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(true);
+        }}
+        aria-label={`Help for ${label}`}
+        className={className}
+      >
+        <CircleHelp className="size-4" />
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="border-game-border bg-game-surface text-game-text"
+          aria-describedby="mode-help-desc"
+        >
+          <DialogHeader>
+            <DialogTitle className="text-lg">{label}</DialogTitle>
+          </DialogHeader>
+          <ModeHelpContent help={help} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/client/src/features/game/components/mode-help-button.tsx
+++ b/apps/client/src/features/game/components/mode-help-button.tsx
@@ -66,10 +66,7 @@ export function ModeHelpButton({
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent
-          className="border-game-border bg-game-surface text-game-text"
-          aria-describedby="mode-help-desc"
-        >
+        <DialogContent className="border-game-border bg-game-surface text-game-text">
           <DialogHeader>
             <DialogTitle className="text-lg">{label}</DialogTitle>
           </DialogHeader>

--- a/apps/client/src/features/game/pages/queue-page.tsx
+++ b/apps/client/src/features/game/pages/queue-page.tsx
@@ -8,6 +8,7 @@ import { GAME_MODE_OPTIONS } from "#/config/ui-constants";
 import { useUser } from "#/features/auth/hooks";
 import { useQueueRoom } from "#/features/game/api/use-queue-room";
 import { ColorPicker } from "#/features/game/components/color-picker";
+import { ModeHelpButton } from "#/features/game/components/mode-help-button";
 import { RoomPlayerList } from "#/features/game/components/room-controls";
 import { GamePage } from "#/features/game/pages/game-page";
 import { Avatar } from "#/features/profile/components/avatar";
@@ -127,7 +128,13 @@ export function QueuePage({
               <p className="text-2xl font-bold">{displayName}</p>
             </div>
           </div>
-          <p className="text-sm text-game-text-dim">Mode: {modeLabel}</p>
+          <div className="flex items-center gap-1">
+            <p className="text-sm text-game-text-dim">Mode: {modeLabel}</p>
+            <ModeHelpButton
+              gameMode={gameMode}
+              className="text-game-text-dim hover:text-game-text"
+            />
+          </div>
         </div>
 
         <div className="grid gap-8 border-t border-game-border pt-8 md:grid-cols-[1fr_20rem]">

--- a/apps/client/src/features/lobby/pages/lobby-page.tsx
+++ b/apps/client/src/features/lobby/pages/lobby-page.tsx
@@ -19,6 +19,7 @@ import {
 import { Input } from "#/components/ui/input";
 import { GAME_MODE_OPTIONS } from "#/config/ui-constants";
 import { useAuth, useUser } from "#/features/auth/hooks";
+import { ModeHelpButton } from "#/features/game/components/mode-help-button";
 import { Avatar } from "#/features/profile/components/avatar";
 import { networkProvider } from "#/infra/network/provider";
 import { HttpRequestError } from "#/infra/network/provider/colyseus";
@@ -34,19 +35,28 @@ function ModeCard({
   onSelect: (mode: GameMode) => void;
 }) {
   return (
-    <Button
-      type="button"
-      variant="outline"
-      disabled={!mode.isEnabled}
-      onClick={() => onSelect(mode.id)}
-      aria-label={`${mode.label}, ${mode.isEnabled ? "Ready" : "Coming soon"}`}
-      className="h-24 w-full flex-col items-start justify-between whitespace-normal border-game-border bg-game-bg p-3 text-left text-game-text hover:border-white/50 hover:bg-game-surface focus-visible:ring-white/30 disabled:opacity-45"
-    >
-      <span className="text-lg font-semibold leading-tight">{mode.label}</span>
-      <span className="text-xs text-game-text-dim">
-        {mode.isEnabled ? "Ready" : "Coming soon"}
-      </span>
-    </Button>
+    <div className="relative">
+      <Button
+        type="button"
+        variant="outline"
+        disabled={!mode.isEnabled}
+        onClick={() => onSelect(mode.id)}
+        aria-label={`${mode.label}, ${mode.isEnabled ? "Ready" : "Coming soon"}`}
+        className="h-24 w-full flex-col items-start justify-between whitespace-normal border-game-border bg-game-bg p-3 text-left text-game-text hover:border-white/50 hover:bg-game-surface focus-visible:ring-white/30 disabled:opacity-45"
+      >
+        <span className="text-lg font-semibold leading-tight">
+          {mode.label}
+        </span>
+        <span className="text-xs text-game-text-dim">
+          {mode.isEnabled ? "Ready" : "Coming soon"}
+        </span>
+      </Button>
+
+      <ModeHelpButton
+        gameMode={mode.id}
+        className="absolute top-1.5 right-1.5 text-game-text-dim hover:text-game-text"
+      />
+    </div>
   );
 }
 

--- a/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
+++ b/apps/client/tests/features/match/flow/client-connection-flow.test.tsx
@@ -320,9 +320,11 @@ describe("client room flows", () => {
     expect(
       await screen.findByRole("dialog", { name: "Choose mode" }),
     ).toBeTruthy();
-    expect(screen.getByRole("button", { name: /Demolition/ })).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: /Demolition, Ready/ }),
+    ).toBeEnabled();
 
-    await user.click(screen.getByRole("button", { name: /Classic/ }));
+    await user.click(screen.getByRole("button", { name: /Classic, Ready/ }));
 
     expect(
       await screen.findByRole("heading", { name: "Pick Your Color" }),
@@ -527,7 +529,9 @@ describe("client room flows", () => {
 
     const user = userEvent.setup();
     await user.click(screen.getByRole("button", { name: "Start" }));
-    await user.click(await screen.findByRole("button", { name: /Classic/ }));
+    await user.click(
+      await screen.findByRole("button", { name: /Classic, Ready/ }),
+    );
     await screen.findByRole("heading", { name: "Pick Your Color" });
 
     queueRoom.emitMessage("seat", reservation);


### PR DESCRIPTION

- Add ModeHelpButton shared component (icon + dialog with summary & rules list)
- Add structured GAME_MODE_HELP data for all 9 game modes in ui-constants
- Show help icon on mode cards in lobby mode picker
- Show help icon next to mode label in queue page
- Show help icon next to Game Mode label in setup room settings