### PR TITLE
feat(server): admin can edit all maps

### DIFF
--- a/apps/client/src/features/map-editor/pages/map-browser-page.tsx
+++ b/apps/client/src/features/map-editor/pages/map-browser-page.tsx
@@ -260,17 +260,18 @@ function MapCard({
         <div className="flex items-center gap-1">
           {(isOwner || isAdmin) && (
             <>
-              {isOwner && (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  onClick={onEdit}
-                  className={`h-7 px-2 ${isEditDisabled ? "opacity-50 cursor-not-allowed" : ""}`}
-                >
-                  <Pencil className="size-3" />
-                </Button>
-              )}
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={onEdit}
+                className={`h-7 px-2 ${isEditDisabled ? "opacity-50 cursor-not-allowed" : ""}`}
+                title={
+                  isAdmin && !isOwner ? "Edit map as Administrator" : "Edit map"
+                }
+              >
+                <Pencil className="size-3" />
+              </Button>
               <Button
                 type="button"
                 size="sm"

--- a/apps/client/src/features/map-editor/store/editor-store.ts
+++ b/apps/client/src/features/map-editor/store/editor-store.ts
@@ -183,8 +183,8 @@ function recomputeBombSiteIndices(cells: CellTemplate[][]): CellTemplate[][] {
     return i;
   };
 
-  return cells.map((row, y) =>
-    row.map((cell, x) => {
+  return cells.map((row, _y) =>
+    row.map((cell, _x) => {
       if (cell.terrain !== T.BOMB_SITE) return cell;
       if (cell.siteIndex !== null) return cell;
       // Newly placed or stripped site: assign smallest available index

--- a/apps/client/src/features/map-editor/store/editor-store.ts
+++ b/apps/client/src/features/map-editor/store/editor-store.ts
@@ -166,13 +166,29 @@ function pushHistory<S extends EditorState>(state: S, next: Partial<S>): S {
 }
 
 function recomputeBombSiteIndices(cells: CellTemplate[][]): CellTemplate[][] {
-  let counter = 0;
-  return cells.map((row) =>
-    row.map((cell) => {
-      if (cell.terrain === T.BOMB_SITE) {
-        return { ...cell, siteIndex: counter++ };
+  // Collect existing indices (excluding the newly placed site)
+  const usedIndices = new Set<number>();
+  for (const row of cells) {
+    for (const cell of row) {
+      if (cell.terrain === T.BOMB_SITE && cell.siteIndex !== null) {
+        usedIndices.add(cell.siteIndex);
       }
-      return cell;
+    }
+  }
+
+  const nextAvailable = (): number => {
+    let i = 0;
+    while (usedIndices.has(i)) i++;
+    usedIndices.add(i);
+    return i;
+  };
+
+  return cells.map((row, y) =>
+    row.map((cell, x) => {
+      if (cell.terrain !== T.BOMB_SITE) return cell;
+      if (cell.siteIndex !== null) return cell;
+      // Newly placed or stripped site: assign smallest available index
+      return { ...cell, siteIndex: nextAvailable() };
     }),
   );
 }
@@ -410,7 +426,7 @@ export const useEditorStore = create<EditorState & EditorActions>(
             newCells = setCellAt(state, coord, {
               terrain: T.BOMB_SITE as Terrain,
               troopCount: null,
-              siteIndex: 0,
+              siteIndex: null,
             });
             if (cell.terrain === T.GENERAL) newSpawns = removeSpawnAt(coord);
             newCells = recomputeBombSiteIndices(newCells);

--- a/apps/server/src/features/maps/map-routes.ts
+++ b/apps/server/src/features/maps/map-routes.ts
@@ -200,7 +200,7 @@ export function registerMapRoutes(app: {
     try {
       const map = await mapRepository.update(
         getParam(request.params, "id"),
-        userId,
+        isAdmin ? undefined : userId,
         result.data,
       );
       if (!map) {

--- a/apps/server/src/infra/db/interfaces.ts
+++ b/apps/server/src/infra/db/interfaces.ts
@@ -111,7 +111,7 @@ export interface IMapRepository {
   }): Promise<{ maps: IMap[]; total: number }>;
   update(
     id: string,
-    authorId: string,
+    authorId: string | undefined,
     update: MapUpdateOptions,
   ): Promise<IMap | null>;
   delete(id: string, authorId?: string): Promise<boolean>;

--- a/apps/server/src/infra/db/repositories/MongoMapRepository.ts
+++ b/apps/server/src/infra/db/repositories/MongoMapRepository.ts
@@ -105,11 +105,15 @@ export class MongoMapRepository implements IMapRepository {
 
   async update(
     id: string,
-    authorId: string,
+    authorId: string | undefined,
     update: MapUpdateOptions,
   ): Promise<IMap | null> {
+    const filter: Record<string, unknown> = { _id: id };
+    if (authorId) {
+      filter.authorId = authorId;
+    }
     const map = await MapModel.findOneAndUpdate(
-      { _id: id, authorId },
+      filter,
       { $set: update },
       { new: true, runValidators: true },
     ).exec();


### PR DESCRIPTION
This pull request introduces improvements to both the map editing experience in the client and the map update logic on the server. On the client, it enhances how bomb site indices are assigned and improves the edit button's usability for admins. On the server, it updates the map editing permissions so that admins can edit any map, not just their own, by making the author check optional.

**Client-side improvements:**

* Improved bomb site index assignment to ensure that new bomb sites are assigned the smallest available index, and that existing indices are preserved. This prevents duplicate indices and gaps when editing maps. (`editor-store.ts` [[1]](diffhunk://#diff-7a2eab10b91f7df99c69337b8d515d0bab7402c606ed1afc31b8aff8a9d0f6b5L169-R191) [[2]](diffhunk://#diff-7a2eab10b91f7df99c69337b8d515d0bab7402c606ed1afc31b8aff8a9d0f6b5L413-R429)
* The edit button in `MapCard` now shows a tooltip indicating when an admin is editing a map they do not own, improving clarity for administrators. (`map-browser-page.tsx` [apps/client/src/features/map-editor/pages/map-browser-page.tsxL263-L273](diffhunk://#diff-88033a52960e4fe2b5318c08b298b2dcfbf2f77ae1f07fe3632147df169f708eL263-L273))

**Server-side improvements:**

* Updated the map update logic so that admins can update any map by making the `authorId` parameter optional in the repository interface and implementation. (`interfaces.ts` [[1]](diffhunk://#diff-96df7983c6a5a2ceeb7f8f087414d2413318da5b01713e7d9ec1352773b03951L114-R114) `MongoMapRepository.ts` [[2]](diffhunk://#diff-e4714307456f74c4cfaf7d7b854c4ae0a6c15a541bc2c58bd45f260345e91771L108-R116)
* Changed the route handler to pass `undefined` as the `authorId` when the user is an admin, allowing admins to bypass the author check. (`map-routes.ts` [apps/server/src/features/maps/map-routes.tsL203-R203](diffhunk://#diff-decba2eed0909dfbf0da908387e4fbcd6dc61bda26a7966f5f98be879ed3afc2L203-R203))