### PR TITLE
feat(engine): respawn when general captured in several modes

### DIFF
--- a/packages/engine/src/domain/game/demolition-game.ts
+++ b/packages/engine/src/domain/game/demolition-game.ts
@@ -2,7 +2,7 @@ import { ActionType } from "#/domain/action/action-type";
 import type { Action } from "#/domain/action/interfaces";
 import type { ICell } from "#/domain/cell/interfaces";
 import { Terrain } from "#/domain/cell/terrain";
-import { StandardCombatResolver } from "#/domain/combat/standard-combat-resolver";
+import { RespawningCombatResolver } from "#/domain/combat/respawning-combat-resolver";
 import { EffectType } from "#/domain/effect/effect-type";
 import { TroopModifierEffect } from "#/domain/effect/periodic/troop-modifier";
 import { BaseGame } from "#/domain/game/base-game";
@@ -33,7 +33,7 @@ export interface DemolitionGameOptions {
 
 export class DemolitionGame extends BaseGame implements IDemolitionGame {
   readonly mode = GameMode.DEMOLITION;
-  private readonly combatResolver = new StandardCombatResolver();
+  private readonly combatResolver = new RespawningCombatResolver();
 
   readonly plantDurationTicks: number;
   readonly defuseDurationTicks: number;

--- a/packages/engine/src/domain/game/payload-game.ts
+++ b/packages/engine/src/domain/game/payload-game.ts
@@ -2,7 +2,7 @@ import { ActionType } from "#/domain/action/action-type";
 import type { Action } from "#/domain/action/interfaces";
 import type { ICell } from "#/domain/cell/interfaces";
 import { Terrain } from "#/domain/cell/terrain";
-import { StandardCombatResolver } from "#/domain/combat/standard-combat-resolver";
+import { RespawningCombatResolver } from "#/domain/combat/respawning-combat-resolver";
 import { EffectType } from "#/domain/effect/effect-type";
 import { TroopModifierEffect } from "#/domain/effect/periodic/troop-modifier";
 import { BaseGame } from "#/domain/game/base-game";
@@ -27,7 +27,7 @@ export interface PayloadGameOptions {
 
 export class PayloadGame extends BaseGame implements IPayloadGame {
   readonly mode = GameMode.PAYLOAD;
-  private readonly combatResolver = new StandardCombatResolver();
+  private readonly combatResolver = new RespawningCombatResolver();
 
   readonly payloadSpeedTicks: number;
   readonly payloadCartSize: number;

--- a/packages/engine/src/domain/game/rugby-game.ts
+++ b/packages/engine/src/domain/game/rugby-game.ts
@@ -2,7 +2,7 @@ import { ActionType } from "#/domain/action/action-type";
 import type { Action } from "#/domain/action/interfaces";
 import type { ICell } from "#/domain/cell/interfaces";
 import { Terrain } from "#/domain/cell/terrain";
-import { StandardCombatResolver } from "#/domain/combat/standard-combat-resolver";
+import { RespawningCombatResolver } from "#/domain/combat/respawning-combat-resolver";
 import { EffectType } from "#/domain/effect/effect-type";
 import { TroopModifierEffect } from "#/domain/effect/periodic/troop-modifier";
 import { BaseGame } from "#/domain/game/base-game";
@@ -26,7 +26,7 @@ export interface RugbyGameOptions {
 
 export class RugbyGame extends BaseGame implements IRugbyGame {
   readonly mode = GameMode.RUGBY;
-  private readonly combatResolver = new StandardCombatResolver();
+  private readonly combatResolver = new RespawningCombatResolver();
 
   readonly rugbyBallCount: number;
   readonly rugbyMoveSpeedTicks: number;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -6,6 +6,7 @@ export * from "#/domain/action/interfaces";
 export * from "#/domain/cell/cell";
 export * from "#/domain/cell/interfaces";
 export * from "#/domain/cell/terrain";
+export * from "#/domain/combat/respawning-combat-resolver";
 export * from "#/domain/combat/standard-combat-resolver";
 export * from "#/domain/effect/effect";
 export * from "#/domain/effect/effect-registry";

--- a/packages/engine/tests/domain/game/demolition-game.test.ts
+++ b/packages/engine/tests/domain/game/demolition-game.test.ts
@@ -476,4 +476,66 @@ describe("DemolitionGame", () => {
     expect(adjCell.item).toBeNull();
     expect(bomb.coordinate).toEqual(siteCell.coordinate);
   });
+
+  it("respawns general instead of instant elimination when a general is captured", () => {
+    const grid = createPlainGrid5x5();
+    const game = new DemolitionGame({ grid });
+
+    const attackers = new AttackerTeam("attackers");
+    const defenders = new DefenderTeam("defenders");
+    const p1 = new Player(attackers, "p1", PlayerStatus.ACTIVE);
+    const p2 = new Player(defenders, "p2", PlayerStatus.ACTIVE);
+
+    game.teams.set(attackers.teamId, attackers);
+    game.teams.set(defenders.teamId, defenders);
+    game.players.set(p1.playerId, p1);
+    game.players.set(p2.playerId, p2);
+
+    game.startGame();
+
+    // Find the generals
+    let p1Gen: Cell | null = null;
+    let p2Gen: Cell | null = null;
+    grid.forEach((c) => {
+      if (c.terrain === Terrain.GENERAL) {
+        if (c.owner?.playerId === "p1") p1Gen = c as Cell;
+        if (c.owner?.playerId === "p2") p2Gen = c as Cell;
+      }
+    });
+
+    expect(p1Gen).not.toBeNull();
+    expect(p2Gen).not.toBeNull();
+    if (!p1Gen || !p2Gen) throw new Error("Generals must exist");
+
+    // Make p2 (defender) own an extra plain cell
+    const p2Plain = grid.get({ x: 3, y: 3 }) as Cell;
+    p2Plain.owner = p2;
+    p2Plain.terrain = Terrain.PLAIN;
+
+    // Position p1 troops next to p2's general
+    const adjacentToP2Gen = grid.getNeighbors(p2Gen.coordinate)[0][0];
+    const attackerCell = grid.get(adjacentToP2Gen) as Cell;
+    attackerCell.owner = p1;
+    attackerCell.troopCount = 20;
+
+    p2Gen.troopCount = 5;
+
+    // Attacker captures p2 general
+    const success = game.handleAction({
+      playerId: "p1",
+      from: attackerCell.coordinate,
+      to: p2Gen.coordinate,
+      type: ActionType.MOVE,
+    });
+    expect(success).toBe(true);
+
+    game.nextTick();
+
+    // Captured general terrain should turn into PLAIN
+    expect(p2Gen.terrain).toBe(Terrain.PLAIN);
+    // Player p2 should still be active (respawned)
+    expect(p2.status).toBe(PlayerStatus.ACTIVE);
+    // The plain cell owned by p2 should be converted to GENERAL
+    expect(p2Plain.terrain).toBe(Terrain.GENERAL);
+  });
 });

--- a/packages/engine/tests/domain/game/payload-game.test.ts
+++ b/packages/engine/tests/domain/game/payload-game.test.ts
@@ -473,4 +473,56 @@ describe("PayloadGame", () => {
     expect(rightGen2.terrain).toBe(Terrain.GENERAL);
     expect(rightGen2.owner?.playerId).toBe("p3");
   });
+
+  it("respawns general instead of instant elimination when a general is captured", () => {
+    const grid = create7x3GridWithTrack();
+    const game = new PayloadGame({ grid });
+
+    const t1 = new StandardTeam("left-team");
+    const t2 = new StandardTeam("right-team");
+    const p1 = new Player(t1, "p1", PlayerStatus.ACTIVE);
+    const p2 = new Player(t2, "p2", PlayerStatus.ACTIVE);
+    game.teams.set(t1.teamId, t1);
+    game.teams.set(t2.teamId, t2);
+    game.players.set(p1.playerId, p1);
+    game.players.set(p2.playerId, p2);
+
+    getCell(grid, { x: 0, y: 1 }).terrain = Terrain.GENERAL;
+    getCell(grid, { x: 0, y: 1 }).owner = p1;
+    getCell(grid, { x: 6, y: 1 }).terrain = Terrain.GENERAL;
+    getCell(grid, { x: 6, y: 1 }).owner = p2;
+
+    game.startGame();
+
+    // Make p2 own an extra plain cell
+    const p2Plain = getCell(grid, { x: 5, y: 1 });
+    p2Plain.owner = p2;
+    p2Plain.terrain = Terrain.PLAIN;
+
+    // Position p1 troops next to p2's general
+    const attackerCell = getCell(grid, { x: 6, y: 2 });
+    attackerCell.owner = p1;
+    attackerCell.troopCount = 20;
+
+    const p2Gen = getCell(grid, { x: 6, y: 1 });
+    p2Gen.troopCount = 5;
+
+    // Attacker captures p2 general
+    const success = game.handleAction({
+      playerId: "p1",
+      from: attackerCell.coordinate,
+      to: p2Gen.coordinate,
+      type: ActionType.MOVE,
+    });
+    expect(success).toBe(true);
+
+    game.nextTick();
+
+    // Captured general terrain should turn into PLAIN
+    expect(p2Gen.terrain).toBe(Terrain.PLAIN);
+    // Player p2 should still be active (respawned)
+    expect(p2.status).toBe(PlayerStatus.ACTIVE);
+    // The plain cell owned by p2 should be converted to GENERAL
+    expect(p2Plain.terrain).toBe(Terrain.GENERAL);
+  });
 });

--- a/packages/engine/tests/domain/game/rugby-game.test.ts
+++ b/packages/engine/tests/domain/game/rugby-game.test.ts
@@ -245,4 +245,56 @@ describe("RugbyGame", () => {
     expect(result?.winnerTeamId).toBe("left-team");
     expect(game.status).toBe(GameStatus.FINISHED);
   });
+
+  it("respawns general instead of instant elimination when a general is captured", () => {
+    const grid = create9x5Grid();
+    const game = new RugbyGame({ grid });
+
+    const t1 = new StandardTeam("left-team");
+    const t2 = new StandardTeam("right-team");
+    const p1 = new Player(t1, "p1", PlayerStatus.ACTIVE);
+    const p2 = new Player(t2, "p2", PlayerStatus.ACTIVE);
+    game.teams.set(t1.teamId, t1);
+    game.teams.set(t2.teamId, t2);
+    game.players.set(p1.playerId, p1);
+    game.players.set(p2.playerId, p2);
+
+    getCell(grid, { x: 1, y: 2 }).terrain = Terrain.GENERAL;
+    getCell(grid, { x: 1, y: 2 }).owner = p1;
+    getCell(grid, { x: 7, y: 2 }).terrain = Terrain.GENERAL;
+    getCell(grid, { x: 7, y: 2 }).owner = p2;
+
+    game.startGame();
+
+    // Make p2 own an extra plain cell
+    const p2Plain = getCell(grid, { x: 6, y: 2 });
+    p2Plain.owner = p2;
+    p2Plain.terrain = Terrain.PLAIN;
+
+    // Position p1 troops next to p2's general
+    const attackerCell = getCell(grid, { x: 8, y: 2 });
+    attackerCell.owner = p1;
+    attackerCell.troopCount = 20;
+
+    const p2Gen = getCell(grid, { x: 7, y: 2 });
+    p2Gen.troopCount = 5;
+
+    // Attacker captures p2 general
+    const success = game.handleAction({
+      playerId: "p1",
+      from: attackerCell.coordinate,
+      to: p2Gen.coordinate,
+      type: ActionType.MOVE,
+    });
+    expect(success).toBe(true);
+
+    game.nextTick();
+
+    // Captured general terrain should turn into PLAIN
+    expect(p2Gen.terrain).toBe(Terrain.PLAIN);
+    // Player p2 should still be active (respawned)
+    expect(p2.status).toBe(PlayerStatus.ACTIVE);
+    // The plain cell owned by p2 should be converted to GENERAL
+    expect(p2Plain.terrain).toBe(Terrain.GENERAL);
+  });
 });


### PR DESCRIPTION
Closes #213 .

This pull request updates the combat resolution logic for the `DemolitionGame`, `PayloadGame`, and `RugbyGame` modes to use a new respawning mechanic when a general is captured, instead of instant player elimination. Corresponding tests have been added to ensure that generals are respawned correctly. Additionally, the new `RespawningCombatResolver` is now exported from the package.

**Gameplay mechanics update:**

* Replaced `StandardCombatResolver` with `RespawningCombatResolver` in `DemolitionGame`, `PayloadGame`, and `RugbyGame`, so that when a general is captured, the player is respawned instead of being immediately eliminated. (`packages/engine/src/domain/game/demolition-game.ts`, `packages/engine/src/domain/game/payload-game.ts`, `packages/engine/src/domain/game/rugby-game.ts`) [[1]](diffhunk://#diff-bf9240d367d7eea761ffbb8488221723b9641b7f513e72bc2128d07f22c49334L5-R5) [[2]](diffhunk://#diff-bf9240d367d7eea761ffbb8488221723b9641b7f513e72bc2128d07f22c49334L36-R36) [[3]](diffhunk://#diff-5ab1359ba3fad711864ec6b09d3b6d0f8851eef7f9f985a93615b7807a6c4b79L5-R5) [[4]](diffhunk://#diff-5ab1359ba3fad711864ec6b09d3b6d0f8851eef7f9f985a93615b7807a6c4b79L30-R30) [[5]](diffhunk://#diff-282714e3ce2f8ea40eb48ceb9ffb0cfdaca1455d4ddacac8d0447a3ebea9e9beL5-R5) [[6]](diffhunk://#diff-282714e3ce2f8ea40eb48ceb9ffb0cfdaca1455d4ddacac8d0447a3ebea9e9beL29-R29)

**Testing enhancements:**

* Added tests to verify that when a general is captured, the player is respawned (their general moves to another owned cell) rather than being eliminated, for all three game modes. (`packages/engine/tests/domain/game/demolition-game.test.ts`, `packages/engine/tests/domain/game/payload-game.test.ts`, `packages/engine/tests/domain/game/rugby-game.test.ts`) [[1]](diffhunk://#diff-342a31f4a1dbe4bc6b9d7278965e4d0c76f867d5e1abf16eba2278442e6f8cc7R479-R540) [[2]](diffhunk://#diff-bdd3a0fc0899e5b4b309d499f44344a845e866acf96b53b67f78f38f4fa3bacbR476-R527) [[3]](diffhunk://#diff-29eee00ac93a997bf60a91df3cad61b9b31885793b27bb33c1c286e7b521566eR248-R299)

**Exports:**

* Exported `RespawningCombatResolver` from the package index to make it available for use elsewhere. (`packages/engine/src/index.ts`)